### PR TITLE
[Issue #196] Corrigindo o erro Rejeicao: 587 - MS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.swconsultoria</groupId>
     <artifactId>java-nfe</artifactId>
-    <version>4.00.14-SNAPSHOT</version>
+    <version>4.00.15-SNAPSHOT</version>
     <name>Java_NFe</name>
     <description>Api java para consumo do webService de nota fiscal eletronica</description>
     <url>https://github.com/Samuel-Oliveira/Java_NFe</url>

--- a/src/main/java/br/com/swconsultoria/nfe/ConsultaXml.java
+++ b/src/main/java/br/com/swconsultoria/nfe/ConsultaXml.java
@@ -2,6 +2,7 @@ package br.com.swconsultoria.nfe;
 
 import br.com.swconsultoria.nfe.dom.ConfiguracoesNfe;
 import br.com.swconsultoria.nfe.dom.enuns.DocumentoEnum;
+import br.com.swconsultoria.nfe.dom.enuns.EstadosEnum;
 import br.com.swconsultoria.nfe.dom.enuns.ServicosEnum;
 import br.com.swconsultoria.nfe.exception.NfeException;
 import br.com.swconsultoria.nfe.schema_4.consSitNFe.TConsSitNFe;
@@ -48,22 +49,41 @@ class ConsultaXml {
 
             OMElement ome = AXIOMUtil.stringToOM(xml);
 
-            NFeConsultaProtocolo4Stub.NfeDadosMsg dadosMsg = new NFeConsultaProtocolo4Stub.NfeDadosMsg();
-            dadosMsg.setExtraElement(ome);
+            if(EstadosEnum.MS.equals(config.getEstado())) {
+                br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4Stub.NfeDadosMsg dadosMsg = new br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4Stub.NfeDadosMsg();
+                dadosMsg.setExtraElement(ome);
 
-            NFeConsultaProtocolo4Stub stub = new NFeConsultaProtocolo4Stub(
-                    WebServiceUtil.getUrl(config, tipoDocumento, ServicosEnum.CONSULTA_XML));
+                br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4Stub stub = new br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4Stub(
+                        WebServiceUtil.getUrl(config, tipoDocumento, ServicosEnum.CONSULTA_XML));
 
-            // Timeout
-            if (ObjetoUtil.verifica(config.getTimeout()).isPresent()) {
-                stub._getServiceClient().getOptions().setProperty(HTTPConstants.SO_TIMEOUT, config.getTimeout());
-                stub._getServiceClient().getOptions().setProperty(HTTPConstants.CONNECTION_TIMEOUT,
-                        config.getTimeout());
+                // Timeout
+                if (ObjetoUtil.verifica(config.getTimeout()).isPresent()) {
+                    stub._getServiceClient().getOptions().setProperty(HTTPConstants.SO_TIMEOUT, config.getTimeout());
+                    stub._getServiceClient().getOptions().setProperty(HTTPConstants.CONNECTION_TIMEOUT,
+                            config.getTimeout());
+                }
+                br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4Stub.NfeResultMsg result = stub.nfeConsultaNF(dadosMsg);
+
+                LoggerUtil.log(ConsultaXml.class, "[XML-RETORNO]: " + result.getExtraElement().toString());
+                return XmlNfeUtil.xmlToObject(result.getExtraElement().toString(), TRetConsSitNFe.class);
+            } else {
+                NFeConsultaProtocolo4Stub.NfeDadosMsg dadosMsg = new NFeConsultaProtocolo4Stub.NfeDadosMsg();
+                dadosMsg.setExtraElement(ome);
+
+                NFeConsultaProtocolo4Stub stub = new NFeConsultaProtocolo4Stub(
+                        WebServiceUtil.getUrl(config, tipoDocumento, ServicosEnum.CONSULTA_XML));
+
+                // Timeout
+                if (ObjetoUtil.verifica(config.getTimeout()).isPresent()) {
+                    stub._getServiceClient().getOptions().setProperty(HTTPConstants.SO_TIMEOUT, config.getTimeout());
+                    stub._getServiceClient().getOptions().setProperty(HTTPConstants.CONNECTION_TIMEOUT,
+                            config.getTimeout());
+                }
+                NFeConsultaProtocolo4Stub.NfeResultMsg result = stub.nfeConsultaNF(dadosMsg);
+
+                LoggerUtil.log(ConsultaXml.class, "[XML-RETORNO]: " + result.getExtraElement().toString());
+                return XmlNfeUtil.xmlToObject(result.getExtraElement().toString(), TRetConsSitNFe.class);
             }
-            NFeConsultaProtocolo4Stub.NfeResultMsg result = stub.nfeConsultaNF(dadosMsg);
-
-            LoggerUtil.log(ConsultaXml.class,"[XML-RETORNO]: " +result.getExtraElement().toString());
-            return XmlNfeUtil.xmlToObject(result.getExtraElement().toString(), TRetConsSitNFe.class);
 
         } catch (RemoteException | XMLStreamException | JAXBException e) {
             throw new NfeException(e.getMessage());

--- a/src/main/java/br/com/swconsultoria/nfe/wsdl/NFeConsultaProtocoloMS/NFeConsultaProtocolo4CallbackHandler.java
+++ b/src/main/java/br/com/swconsultoria/nfe/wsdl/NFeConsultaProtocoloMS/NFeConsultaProtocolo4CallbackHandler.java
@@ -1,0 +1,55 @@
+/**
+ * NFeConsultaProtocolo4CallbackHandler.java
+ *
+ * This file was auto-generated from WSDL
+ * by the Apache Axis2 version: 1.7.5  Built on : May 06, 2017 (03:45:26 BST)
+ */
+package br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS;
+
+
+/**
+ *  NFeConsultaProtocolo4CallbackHandler Callback class, Users can extend this class and implement
+ *  their own receiveResult and receiveError methods.
+ */
+public abstract class NFeConsultaProtocolo4CallbackHandler {
+    protected Object clientData;
+
+    /**
+     * User can pass in any object that needs to be accessed once the NonBlocking
+     * Web service call is finished and appropriate method of this CallBack is called.
+     * @param clientData Object mechanism by which the user can pass in user data
+     * that will be avilable at the time this callback is called.
+     */
+    public NFeConsultaProtocolo4CallbackHandler(Object clientData) {
+        this.clientData = clientData;
+    }
+
+    /**
+     * Please use this constructor if you don't want to set any clientData
+     */
+    public NFeConsultaProtocolo4CallbackHandler() {
+        this.clientData = null;
+    }
+
+    /**
+     * Get the client data
+     */
+    public Object getClientData() {
+        return clientData;
+    }
+
+    /**
+     * auto generated Axis2 call back method for nfeConsultaNF method
+     * override this method for handling normal response from nfeConsultaNF operation
+     */
+    public void receiveResultnfeConsultaNF(
+        NFeConsultaProtocolo4Stub.NfeResultMsg result) {
+    }
+
+    /**
+     * auto generated Axis2 Error handler
+     * override this method for handling error response from nfeConsultaNF operation
+     */
+    public void receiveErrornfeConsultaNF(Exception e) {
+    }
+}

--- a/src/main/java/br/com/swconsultoria/nfe/wsdl/NFeConsultaProtocoloMS/NFeConsultaProtocolo4Stub.java
+++ b/src/main/java/br/com/swconsultoria/nfe/wsdl/NFeConsultaProtocoloMS/NFeConsultaProtocolo4Stub.java
@@ -1,0 +1,1271 @@
+/**
+ * NFeConsultaProtocolo4Stub.java
+ *
+ * This file was auto-generated from WSDL
+ * by the Apache Axis2 version: 1.7.5  Built on : May 06, 2017 (03:45:26 BST)
+ */
+package br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS;
+
+
+/*
+ *  NFeConsultaProtocolo4Stub java implementation
+ */
+public class NFeConsultaProtocolo4Stub extends org.apache.axis2.client.Stub {
+    private static int counter = 0;
+    protected org.apache.axis2.description.AxisOperation[] _operations;
+
+    //hashmaps to keep the fault mapping
+    private java.util.HashMap faultExceptionNameMap = new java.util.HashMap();
+    private java.util.HashMap faultExceptionClassNameMap = new java.util.HashMap();
+    private java.util.HashMap faultMessageMap = new java.util.HashMap();
+    private javax.xml.namespace.QName[] opNameArray = null;
+
+    /**
+     *Constructor that takes in a configContext
+     */
+    public NFeConsultaProtocolo4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext,
+        String targetEndpoint) throws org.apache.axis2.AxisFault {
+        this(configurationContext, targetEndpoint, false);
+    }
+
+    /**
+     * Constructor that takes in a configContext  and useseperate listner
+     */
+    public NFeConsultaProtocolo4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext,
+        String targetEndpoint, boolean useSeparateListener)
+        throws org.apache.axis2.AxisFault {
+        //To populate AxisService
+        populateAxisService();
+        populateFaults();
+
+        _serviceClient = new org.apache.axis2.client.ServiceClient(configurationContext,
+                _service);
+
+        _serviceClient.getOptions()
+                      .setTo(new org.apache.axis2.addressing.EndpointReference(
+                targetEndpoint));
+        _serviceClient.getOptions().setUseSeparateListener(useSeparateListener);
+
+        //Set the soap version
+        _serviceClient.getOptions()
+                      .setSoapVersionURI(org.apache.axiom.soap.SOAP12Constants.SOAP_ENVELOPE_NAMESPACE_URI);
+    }
+
+    /**
+     * Default Constructor
+     */
+    public NFeConsultaProtocolo4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext)
+        throws org.apache.axis2.AxisFault {
+        this(configurationContext,
+            "https://nfe.sefaz.ms.gov.br/ws/NFeConsultaProtocolo4");
+    }
+
+    /**
+     * Default Constructor
+     */
+    public NFeConsultaProtocolo4Stub() throws org.apache.axis2.AxisFault {
+        this("https://nfe.sefaz.ms.gov.br/ws/NFeConsultaProtocolo4");
+    }
+
+    /**
+     * Constructor taking the target endpoint
+     */
+    public NFeConsultaProtocolo4Stub(String targetEndpoint)
+        throws org.apache.axis2.AxisFault {
+        this(null, targetEndpoint);
+    }
+
+    private static synchronized String getUniqueSuffix() {
+        // reset the counter if it is greater than 99999
+        if (counter > 99999) {
+            counter = 0;
+        }
+
+        counter = counter + 1;
+
+        return Long.toString(System.currentTimeMillis()) +
+        "_" + counter;
+    }
+
+    private void populateAxisService() throws org.apache.axis2.AxisFault {
+        //creating the Service with a unique name
+        _service = new org.apache.axis2.description.AxisService(
+                "NFeConsultaProtocolo4" + getUniqueSuffix());
+        addAnonymousOperations();
+
+        //creating the operations
+        org.apache.axis2.description.AxisOperation __operation;
+
+        _operations = new org.apache.axis2.description.AxisOperation[1];
+
+        __operation = new org.apache.axis2.description.OutInAxisOperation();
+
+        __operation.setName(new javax.xml.namespace.QName(
+                "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                "nfeConsultaNF"));
+        _service.addOperation(__operation);
+
+        _operations[0] = __operation;
+    }
+
+    //populates the faults
+    private void populateFaults() {
+    }
+
+    /**
+     * Auto generated method signature
+     *
+     * @see br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4#nfeConsultaNF
+     * @param nfeDadosMsg0
+     */
+    public NfeResultMsg nfeConsultaNF(
+        NfeDadosMsg nfeDadosMsg0)
+        throws java.rmi.RemoteException {
+        org.apache.axis2.context.MessageContext _messageContext = null;
+
+        try {
+            org.apache.axis2.client.OperationClient _operationClient = _serviceClient.createClient(_operations[0].getName());
+            _operationClient.getOptions()
+                            .setAction("http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4/nfeConsultaNF");
+            _operationClient.getOptions().setExceptionToBeThrownOnSOAPFault(true);
+
+            addPropertyToOperationClient(_operationClient,
+                org.apache.axis2.description.WSDL2Constants.ATTR_WHTTP_QUERY_PARAMETER_SEPARATOR,
+                "&");
+
+            // create a message context
+            _messageContext = new org.apache.axis2.context.MessageContext();
+
+            // create SOAP envelope with that payload
+            org.apache.axiom.soap.SOAPEnvelope env = null;
+
+            env = toEnvelope(getFactory(_operationClient.getOptions()
+                                                        .getSoapVersionURI()),
+                    nfeDadosMsg0,
+                    optimizeContent(
+                        new javax.xml.namespace.QName(
+                            "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                            "nfeConsultaNF")),
+                    new javax.xml.namespace.QName(
+                        "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                        "nfeDadosMsg"));
+
+            //adding SOAP soap_headers
+            _serviceClient.addHeadersToEnvelope(env);
+            // set the message context with that soap envelope
+            _messageContext.setEnvelope(env);
+
+            // add the message contxt to the operation client
+            _operationClient.addMessageContext(_messageContext);
+
+            //execute the operation client
+            _operationClient.execute(true);
+
+            org.apache.axis2.context.MessageContext _returnMessageContext = _operationClient.getMessageContext(org.apache.axis2.wsdl.WSDLConstants.MESSAGE_LABEL_IN_VALUE);
+            org.apache.axiom.soap.SOAPEnvelope _returnEnv = _returnMessageContext.getEnvelope();
+
+            Object object = fromOM(_returnEnv.getBody()
+                                                       .getFirstElement(),
+                    NfeResultMsg.class);
+
+            return (NfeResultMsg) object;
+        } catch (org.apache.axis2.AxisFault f) {
+            org.apache.axiom.om.OMElement faultElt = f.getDetail();
+
+            if (faultElt != null) {
+                if (faultExceptionNameMap.containsKey(
+                            new org.apache.axis2.client.FaultMapKey(
+                                faultElt.getQName(), "nfeConsultaNF"))) {
+                    //make the fault by reflection
+                    try {
+                        String exceptionClassName = (String) faultExceptionClassNameMap.get(new org.apache.axis2.client.FaultMapKey(
+                                    faultElt.getQName(), "nfeConsultaNF"));
+                        Class exceptionClass = Class.forName(exceptionClassName);
+                        java.lang.reflect.Constructor constructor = exceptionClass.getConstructor(String.class);
+                        Exception ex = (Exception) constructor.newInstance(f.getMessage());
+
+                        //message class
+                        String messageClassName = (String) faultMessageMap.get(new org.apache.axis2.client.FaultMapKey(
+                                    faultElt.getQName(), "nfeConsultaNF"));
+                        Class messageClass = Class.forName(messageClassName);
+                        Object messageObject = fromOM(faultElt,
+                                messageClass);
+                        java.lang.reflect.Method m = exceptionClass.getMethod("setFaultMessage",
+                                new Class[] { messageClass });
+                        m.invoke(ex, new Object[] { messageObject });
+
+                        throw new java.rmi.RemoteException(ex.getMessage(), ex);
+                    } catch (ClassCastException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (ClassNotFoundException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (NoSuchMethodException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.reflect.InvocationTargetException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (IllegalAccessException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (InstantiationException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    }
+                } else {
+                    throw f;
+                }
+            } else {
+                throw f;
+            }
+        } finally {
+            if (_messageContext.getTransportOut() != null) {
+                _messageContext.getTransportOut().getSender()
+                               .cleanup(_messageContext);
+            }
+        }
+    }
+
+    /**
+     * Auto generated method signature for Asynchronous Invocations
+     *
+     * @see br.com.swconsultoria.nfe.wsdl.NFeConsultaProtocoloMS.NFeConsultaProtocolo4#startnfeConsultaNF
+     * @param nfeDadosMsg0
+     */
+    public void startnfeConsultaNF(
+        NfeDadosMsg nfeDadosMsg0,
+        final NFeConsultaProtocolo4CallbackHandler callback)
+        throws java.rmi.RemoteException {
+        org.apache.axis2.client.OperationClient _operationClient = _serviceClient.createClient(_operations[0].getName());
+        _operationClient.getOptions()
+                        .setAction("http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4/nfeConsultaNF");
+        _operationClient.getOptions().setExceptionToBeThrownOnSOAPFault(true);
+
+        addPropertyToOperationClient(_operationClient,
+            org.apache.axis2.description.WSDL2Constants.ATTR_WHTTP_QUERY_PARAMETER_SEPARATOR,
+            "&");
+
+        // create SOAP envelope with that payload
+        org.apache.axiom.soap.SOAPEnvelope env = null;
+        final org.apache.axis2.context.MessageContext _messageContext = new org.apache.axis2.context.MessageContext();
+
+        //Style is Doc.
+        env = toEnvelope(getFactory(_operationClient.getOptions()
+                                                    .getSoapVersionURI()),
+                nfeDadosMsg0,
+                optimizeContent(
+                    new javax.xml.namespace.QName(
+                        "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                        "nfeConsultaNF")),
+                new javax.xml.namespace.QName(
+                    "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                    "nfeDadosMsg"));
+
+        // adding SOAP soap_headers
+        _serviceClient.addHeadersToEnvelope(env);
+        // create message context with that soap envelope
+        _messageContext.setEnvelope(env);
+
+        // add the message context to the operation client
+        _operationClient.addMessageContext(_messageContext);
+
+        _operationClient.setCallback(new org.apache.axis2.client.async.AxisCallback() {
+                public void onMessage(
+                    org.apache.axis2.context.MessageContext resultContext) {
+                    try {
+                        org.apache.axiom.soap.SOAPEnvelope resultEnv = resultContext.getEnvelope();
+
+                        Object object = fromOM(resultEnv.getBody()
+                                                                  .getFirstElement(),
+                                NfeResultMsg.class);
+                        callback.receiveResultnfeConsultaNF((NfeResultMsg) object);
+                    } catch (org.apache.axis2.AxisFault e) {
+                        callback.receiveErrornfeConsultaNF(e);
+                    }
+                }
+
+                public void onError(Exception error) {
+                    if (error instanceof org.apache.axis2.AxisFault) {
+                        org.apache.axis2.AxisFault f = (org.apache.axis2.AxisFault) error;
+                        org.apache.axiom.om.OMElement faultElt = f.getDetail();
+
+                        if (faultElt != null) {
+                            if (faultExceptionNameMap.containsKey(
+                                        new org.apache.axis2.client.FaultMapKey(
+                                            faultElt.getQName(), "nfeConsultaNF"))) {
+                                //make the fault by reflection
+                                try {
+                                    String exceptionClassName = (String) faultExceptionClassNameMap.get(new org.apache.axis2.client.FaultMapKey(
+                                                faultElt.getQName(),
+                                                "nfeConsultaNF"));
+                                    Class exceptionClass = Class.forName(exceptionClassName);
+                                    java.lang.reflect.Constructor constructor = exceptionClass.getConstructor(String.class);
+                                    Exception ex = (Exception) constructor.newInstance(f.getMessage());
+
+                                    //message class
+                                    String messageClassName = (String) faultMessageMap.get(new org.apache.axis2.client.FaultMapKey(
+                                                faultElt.getQName(),
+                                                "nfeConsultaNF"));
+                                    Class messageClass = Class.forName(messageClassName);
+                                    Object messageObject = fromOM(faultElt,
+                                            messageClass);
+                                    java.lang.reflect.Method m = exceptionClass.getMethod("setFaultMessage",
+                                            new Class[] { messageClass });
+                                    m.invoke(ex,
+                                        new Object[] { messageObject });
+
+                                    callback.receiveErrornfeConsultaNF(new java.rmi.RemoteException(
+                                            ex.getMessage(), ex));
+                                } catch (ClassCastException e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                } catch (ClassNotFoundException e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                } catch (NoSuchMethodException e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                } catch (java.lang.reflect.InvocationTargetException e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                } catch (IllegalAccessException e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                } catch (InstantiationException e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                } catch (org.apache.axis2.AxisFault e) {
+                                    // we cannot intantiate the class - throw the original Axis fault
+                                    callback.receiveErrornfeConsultaNF(f);
+                                }
+                            } else {
+                                callback.receiveErrornfeConsultaNF(f);
+                            }
+                        } else {
+                            callback.receiveErrornfeConsultaNF(f);
+                        }
+                    } else {
+                        callback.receiveErrornfeConsultaNF(error);
+                    }
+                }
+
+                public void onFault(
+                    org.apache.axis2.context.MessageContext faultContext) {
+                    org.apache.axis2.AxisFault fault = org.apache.axis2.util.Utils.getInboundFaultFromMessageContext(faultContext);
+                    onError(fault);
+                }
+
+                public void onComplete() {
+                    try {
+                        _messageContext.getTransportOut().getSender()
+                                       .cleanup(_messageContext);
+                    } catch (org.apache.axis2.AxisFault axisFault) {
+                        callback.receiveErrornfeConsultaNF(axisFault);
+                    }
+                }
+            });
+
+        org.apache.axis2.util.CallbackReceiver _callbackReceiver = null;
+
+        if ((_operations[0].getMessageReceiver() == null) &&
+                _operationClient.getOptions().isUseSeparateListener()) {
+            _callbackReceiver = new org.apache.axis2.util.CallbackReceiver();
+            _operations[0].setMessageReceiver(_callbackReceiver);
+        }
+
+        //execute the operation client
+        _operationClient.execute(false);
+    }
+
+    private boolean optimizeContent(javax.xml.namespace.QName opName) {
+        if (opNameArray == null) {
+            return false;
+        }
+
+        for (int i = 0; i < opNameArray.length; i++) {
+            if (opName.equals(opNameArray[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private org.apache.axiom.om.OMElement toOM(
+        NfeDadosMsg param,
+        boolean optimizeContent) throws org.apache.axis2.AxisFault {
+        try {
+            return param.getOMElement(NfeDadosMsg.MY_QNAME,
+                org.apache.axiom.om.OMAbstractFactory.getOMFactory());
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    private org.apache.axiom.om.OMElement toOM(
+        NfeResultMsg param,
+        boolean optimizeContent) throws org.apache.axis2.AxisFault {
+        try {
+            return param.getOMElement(NfeResultMsg.MY_QNAME,
+                org.apache.axiom.om.OMAbstractFactory.getOMFactory());
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    private org.apache.axiom.soap.SOAPEnvelope toEnvelope(
+        org.apache.axiom.soap.SOAPFactory factory,
+        NfeDadosMsg param,
+        boolean optimizeContent, javax.xml.namespace.QName elementQName)
+        throws org.apache.axis2.AxisFault {
+        try {
+            org.apache.axiom.soap.SOAPEnvelope emptyEnvelope = factory.getDefaultEnvelope();
+            emptyEnvelope.getBody()
+                         .addChild(param.getOMElement(
+                    NfeDadosMsg.MY_QNAME,
+                    factory));
+
+            return emptyEnvelope;
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    /* methods to provide back word compatibility */
+
+    /**
+     *  get the default envelope
+     */
+    private org.apache.axiom.soap.SOAPEnvelope toEnvelope(
+        org.apache.axiom.soap.SOAPFactory factory) {
+        return factory.getDefaultEnvelope();
+    }
+
+    private Object fromOM(org.apache.axiom.om.OMElement param,
+        Class type) throws org.apache.axis2.AxisFault {
+        try {
+            if (NfeDadosMsg.class.equals(
+                        type)) {
+                return NfeDadosMsg.Factory.parse(param.getXMLStreamReaderWithoutCaching());
+            }
+
+            if (NfeResultMsg.class.equals(
+                        type)) {
+                return NfeResultMsg.Factory.parse(param.getXMLStreamReaderWithoutCaching());
+            }
+        } catch (Exception e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+
+        return null;
+    }
+
+    //https://nfe.sefaz.ms.gov.br/ws/NFeConsultaProtocolo4
+    public static class NfeResultMsg implements org.apache.axis2.databinding.ADBBean {
+        public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                "nfeResultMsg", "");
+
+        /**
+         * field for ExtraElement
+         */
+        protected org.apache.axiom.om.OMElement localExtraElement;
+
+        /**
+         * Auto generated getter method
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getExtraElement() {
+            return localExtraElement;
+        }
+
+        /**
+         * Auto generated setter method
+         * @param param ExtraElement
+         */
+        public void setExtraElement(org.apache.axiom.om.OMElement param) {
+            this.localExtraElement = param;
+        }
+
+        /**
+         *
+         * @param parentQName
+         * @param factory
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getOMElement(
+            final javax.xml.namespace.QName parentQName,
+            final org.apache.axiom.om.OMFactory factory)
+            throws org.apache.axis2.databinding.ADBException {
+            return factory.createOMElement(new org.apache.axis2.databinding.ADBDataSource(
+                    this, MY_QNAME));
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            serialize(parentQName, xmlWriter, false);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter, boolean serializeType)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            String prefix = null;
+            String namespace = null;
+
+            prefix = parentQName.getPrefix();
+            namespace = parentQName.getNamespaceURI();
+            writeStartElement(prefix, namespace, parentQName.getLocalPart(),
+                xmlWriter);
+
+            if (serializeType) {
+                String namespacePrefix = registerPrefix(xmlWriter,
+                        "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4");
+
+                if ((namespacePrefix != null) &&
+                        (namespacePrefix.trim().length() > 0)) {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        namespacePrefix + ":nfeResultMsg", xmlWriter);
+                } else {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        "nfeResultMsg", xmlWriter);
+                }
+            }
+
+            if (localExtraElement != null) {
+                localExtraElement.serialize(xmlWriter);
+            } else {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "extraElement cannot be null!!");
+            }
+
+            xmlWriter.writeEndElement();
+        }
+
+        private static String generatePrefix(
+            String namespace) {
+            if (namespace.equals(
+                        "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4")) {
+                return "";
+            }
+
+            return org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+        }
+
+        /**
+         * Utility method to write an element start tag.
+         */
+        private void writeStartElement(String prefix,
+                                       String namespace, String localPart,
+                                       javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeStartElement(writerPrefix, localPart, namespace);
+            } else {
+                if (namespace.length() == 0) {
+                    prefix = "";
+                } else if (prefix == null) {
+                    prefix = generatePrefix(namespace);
+                }
+
+                xmlWriter.writeStartElement(prefix, localPart, namespace);
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+        }
+
+        /**
+         * Util method to write an attribute with the ns prefix
+         */
+        private void writeAttribute(String prefix,
+                                    String namespace, String attName,
+                                    String attValue,
+                                    javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeAttribute(writerPrefix, namespace, attName,
+                    attValue);
+            } else {
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+                xmlWriter.writeAttribute(prefix, namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeAttribute(String namespace,
+                                    String attName, String attValue,
+                                    javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attValue);
+            } else {
+                xmlWriter.writeAttribute(registerPrefix(xmlWriter, namespace),
+                    namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeQNameAttribute(String namespace,
+                                         String attName, javax.xml.namespace.QName qname,
+                                         javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String attributeNamespace = qname.getNamespaceURI();
+            String attributePrefix = xmlWriter.getPrefix(attributeNamespace);
+
+            if (attributePrefix == null) {
+                attributePrefix = registerPrefix(xmlWriter, attributeNamespace);
+            }
+
+            String attributeValue;
+
+            if (attributePrefix.trim().length() > 0) {
+                attributeValue = attributePrefix + ":" + qname.getLocalPart();
+            } else {
+                attributeValue = qname.getLocalPart();
+            }
+
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attributeValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(attributePrefix, namespace, attName,
+                    attributeValue);
+            }
+        }
+
+        /**
+         *  method to handle Qnames
+         */
+        private void writeQName(javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String namespaceURI = qname.getNamespaceURI();
+
+            if (namespaceURI != null) {
+                String prefix = xmlWriter.getPrefix(namespaceURI);
+
+                if (prefix == null) {
+                    prefix = generatePrefix(namespaceURI);
+                    xmlWriter.writeNamespace(prefix, namespaceURI);
+                    xmlWriter.setPrefix(prefix, namespaceURI);
+                }
+
+                if (prefix.trim().length() > 0) {
+                    xmlWriter.writeCharacters(prefix + ":" +
+                        org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                } else {
+                    // i.e this is the default namespace
+                    xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                }
+            } else {
+                xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        qname));
+            }
+        }
+
+        private void writeQNames(javax.xml.namespace.QName[] qnames,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (qnames != null) {
+                // we have to store this data until last moment since it is not possible to write any
+                // namespace data after writing the charactor data
+                StringBuffer stringToWrite = new StringBuffer();
+                String namespaceURI = null;
+                String prefix = null;
+
+                for (int i = 0; i < qnames.length; i++) {
+                    if (i > 0) {
+                        stringToWrite.append(" ");
+                    }
+
+                    namespaceURI = qnames[i].getNamespaceURI();
+
+                    if (namespaceURI != null) {
+                        prefix = xmlWriter.getPrefix(namespaceURI);
+
+                        if ((prefix == null) || (prefix.length() == 0)) {
+                            prefix = generatePrefix(namespaceURI);
+                            xmlWriter.writeNamespace(prefix, namespaceURI);
+                            xmlWriter.setPrefix(prefix, namespaceURI);
+                        }
+
+                        if (prefix.trim().length() > 0) {
+                            stringToWrite.append(prefix).append(":")
+                                         .append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        } else {
+                            stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        }
+                    } else {
+                        stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                qnames[i]));
+                    }
+                }
+
+                xmlWriter.writeCharacters(stringToWrite.toString());
+            }
+        }
+
+        /**
+         * Register a namespace prefix
+         */
+        private String registerPrefix(
+            javax.xml.stream.XMLStreamWriter xmlWriter,
+            String namespace)
+            throws javax.xml.stream.XMLStreamException {
+            String prefix = xmlWriter.getPrefix(namespace);
+
+            if (prefix == null) {
+                prefix = generatePrefix(namespace);
+
+                javax.xml.namespace.NamespaceContext nsContext = xmlWriter.getNamespaceContext();
+
+                while (true) {
+                    String uri = nsContext.getNamespaceURI(prefix);
+
+                    if ((uri == null) || (uri.length() == 0)) {
+                        break;
+                    }
+
+                    prefix = org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+                }
+
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            return prefix;
+        }
+
+        /**
+         *  Factory class that keeps the parse method
+         */
+        public static class Factory {
+            private static org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(Factory.class);
+
+            /**
+             * static method to create the object
+             * Precondition:  If this object is an element, the current or next start element starts this object and any intervening reader events are ignorable
+             *                If this object is not an element, it is a complex type and the reader is at the event just after the outer start element
+             * Postcondition: If this object is an element, the reader is positioned at its end element
+             *                If this object is a complex type, the reader is positioned at the end element of its outer element
+             */
+            public static NfeResultMsg parse(
+                javax.xml.stream.XMLStreamReader reader)
+                throws Exception {
+                NfeResultMsg object = new NfeResultMsg();
+
+                int event;
+                javax.xml.namespace.QName currentQName = null;
+                String nillableValue = null;
+                String prefix = "";
+                String namespaceuri = "";
+
+                try {
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    currentQName = reader.getName();
+
+                    if (reader.getAttributeValue(
+                                "http://www.w3.org/2001/XMLSchema-instance",
+                                "type") != null) {
+                        String fullTypeName = reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance",
+                                "type");
+
+                        if (fullTypeName != null) {
+                            String nsPrefix = null;
+
+                            if (fullTypeName.indexOf(":") > -1) {
+                                nsPrefix = fullTypeName.substring(0,
+                                        fullTypeName.indexOf(":"));
+                            }
+
+                            nsPrefix = (nsPrefix == null) ? "" : nsPrefix;
+
+                            String type = fullTypeName.substring(fullTypeName.indexOf(
+                                        ":") + 1);
+
+                            if (!"nfeResultMsg".equals(type)) {
+                                //find namespace for the prefix
+                                String nsUri = reader.getNamespaceContext()
+                                                               .getNamespaceURI(nsPrefix);
+
+                                return (NfeResultMsg) ExtensionMapper.getTypeObject(nsUri,
+                                    type, reader);
+                            }
+                        }
+                    }
+
+                    // Note all attributes that were handled. Used to differ normal attributes
+                    // from anyAttributes.
+                    java.util.Vector handledAttributes = new java.util.Vector();
+
+                    reader.next();
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        //use the QName from the parser as the name for the builder
+                        javax.xml.namespace.QName startQname1 = reader.getName();
+
+                        // We need to wrap the reader so that it produces a fake START_DOCUMENT event
+                        // this is needed by the builder classes
+                        org.apache.axis2.databinding.utils.NamedStaxOMBuilder builder1 =
+                            new org.apache.axis2.databinding.utils.NamedStaxOMBuilder(new org.apache.axis2.util.StreamWrapper(
+                                    reader), startQname1);
+                        object.setExtraElement(builder1.getOMElement());
+
+                        reader.next();
+                    } // End of if for expected property start element
+
+                    else {
+                        // 1 - A start element we are not expecting indicates an invalid parameter was passed
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        // 2 - A start element we are not expecting indicates a trailing invalid property
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+                } catch (javax.xml.stream.XMLStreamException e) {
+                    throw new Exception(e);
+                }
+
+                return object;
+            }
+        } //end of factory class
+    }
+
+    public static class NfeDadosMsg implements org.apache.axis2.databinding.ADBBean {
+        public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4",
+                "nfeDadosMsg", "");
+
+        /**
+         * field for ExtraElement
+         */
+        protected org.apache.axiom.om.OMElement localExtraElement;
+
+        /**
+         * Auto generated getter method
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getExtraElement() {
+            return localExtraElement;
+        }
+
+        /**
+         * Auto generated setter method
+         * @param param ExtraElement
+         */
+        public void setExtraElement(org.apache.axiom.om.OMElement param) {
+            this.localExtraElement = param;
+        }
+
+        /**
+         *
+         * @param parentQName
+         * @param factory
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getOMElement(
+            final javax.xml.namespace.QName parentQName,
+            final org.apache.axiom.om.OMFactory factory)
+            throws org.apache.axis2.databinding.ADBException {
+            return factory.createOMElement(new org.apache.axis2.databinding.ADBDataSource(
+                    this, MY_QNAME));
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            serialize(parentQName, xmlWriter, false);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter, boolean serializeType)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            String prefix = null;
+            String namespace = null;
+
+            prefix = parentQName.getPrefix();
+            namespace = parentQName.getNamespaceURI();
+            writeStartElement(prefix, namespace, parentQName.getLocalPart(),
+                xmlWriter);
+
+            if (serializeType) {
+                String namespacePrefix = registerPrefix(xmlWriter,
+                        "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4");
+
+                if ((namespacePrefix != null) &&
+                        (namespacePrefix.trim().length() > 0)) {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        namespacePrefix + ":nfeDadosMsg", xmlWriter);
+                } else {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        "nfeDadosMsg", xmlWriter);
+                }
+            }
+
+            if (localExtraElement != null) {
+                localExtraElement.serialize(xmlWriter);
+            } else {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "extraElement cannot be null!!");
+            }
+
+            xmlWriter.writeEndElement();
+        }
+
+        private static String generatePrefix(
+            String namespace) {
+            if (namespace.equals(
+                        "http://www.portalfiscal.inf.br/nfe/wsdl/NFeConsultaProtocolo4")) {
+                return "";
+            }
+
+            return org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+        }
+
+        /**
+         * Utility method to write an element start tag.
+         */
+        private void writeStartElement(String prefix,
+                                       String namespace, String localPart,
+                                       javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeStartElement(writerPrefix, localPart, namespace);
+            } else {
+                if (namespace.length() == 0) {
+                    prefix = "";
+                } else if (prefix == null) {
+                    prefix = generatePrefix(namespace);
+                }
+
+                xmlWriter.writeStartElement(prefix, localPart, namespace);
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+        }
+
+        /**
+         * Util method to write an attribute with the ns prefix
+         */
+        private void writeAttribute(String prefix,
+                                    String namespace, String attName,
+                                    String attValue,
+                                    javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeAttribute(writerPrefix, namespace, attName,
+                    attValue);
+            } else {
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+                xmlWriter.writeAttribute(prefix, namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeAttribute(String namespace,
+                                    String attName, String attValue,
+                                    javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attValue);
+            } else {
+                xmlWriter.writeAttribute(registerPrefix(xmlWriter, namespace),
+                    namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeQNameAttribute(String namespace,
+                                         String attName, javax.xml.namespace.QName qname,
+                                         javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String attributeNamespace = qname.getNamespaceURI();
+            String attributePrefix = xmlWriter.getPrefix(attributeNamespace);
+
+            if (attributePrefix == null) {
+                attributePrefix = registerPrefix(xmlWriter, attributeNamespace);
+            }
+
+            String attributeValue;
+
+            if (attributePrefix.trim().length() > 0) {
+                attributeValue = attributePrefix + ":" + qname.getLocalPart();
+            } else {
+                attributeValue = qname.getLocalPart();
+            }
+
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attributeValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(attributePrefix, namespace, attName,
+                    attributeValue);
+            }
+        }
+
+        /**
+         *  method to handle Qnames
+         */
+        private void writeQName(javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            String namespaceURI = qname.getNamespaceURI();
+
+            if (namespaceURI != null) {
+                String prefix = xmlWriter.getPrefix(namespaceURI);
+
+                if (prefix == null) {
+                    prefix = generatePrefix(namespaceURI);
+                    xmlWriter.writeNamespace(prefix, namespaceURI);
+                    xmlWriter.setPrefix(prefix, namespaceURI);
+                }
+
+                if (prefix.trim().length() > 0) {
+                    xmlWriter.writeCharacters(prefix + ":" +
+                        org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                } else {
+                    // i.e this is the default namespace
+                    xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                }
+            } else {
+                xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        qname));
+            }
+        }
+
+        private void writeQNames(javax.xml.namespace.QName[] qnames,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (qnames != null) {
+                // we have to store this data until last moment since it is not possible to write any
+                // namespace data after writing the charactor data
+                StringBuffer stringToWrite = new StringBuffer();
+                String namespaceURI = null;
+                String prefix = null;
+
+                for (int i = 0; i < qnames.length; i++) {
+                    if (i > 0) {
+                        stringToWrite.append(" ");
+                    }
+
+                    namespaceURI = qnames[i].getNamespaceURI();
+
+                    if (namespaceURI != null) {
+                        prefix = xmlWriter.getPrefix(namespaceURI);
+
+                        if ((prefix == null) || (prefix.length() == 0)) {
+                            prefix = generatePrefix(namespaceURI);
+                            xmlWriter.writeNamespace(prefix, namespaceURI);
+                            xmlWriter.setPrefix(prefix, namespaceURI);
+                        }
+
+                        if (prefix.trim().length() > 0) {
+                            stringToWrite.append(prefix).append(":")
+                                         .append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        } else {
+                            stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        }
+                    } else {
+                        stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                qnames[i]));
+                    }
+                }
+
+                xmlWriter.writeCharacters(stringToWrite.toString());
+            }
+        }
+
+        /**
+         * Register a namespace prefix
+         */
+        private String registerPrefix(
+            javax.xml.stream.XMLStreamWriter xmlWriter,
+            String namespace)
+            throws javax.xml.stream.XMLStreamException {
+            String prefix = xmlWriter.getPrefix(namespace);
+
+            if (prefix == null) {
+                prefix = generatePrefix(namespace);
+
+                javax.xml.namespace.NamespaceContext nsContext = xmlWriter.getNamespaceContext();
+
+                while (true) {
+                    String uri = nsContext.getNamespaceURI(prefix);
+
+                    if ((uri == null) || (uri.length() == 0)) {
+                        break;
+                    }
+
+                    prefix = org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+                }
+
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            return prefix;
+        }
+
+        /**
+         *  Factory class that keeps the parse method
+         */
+        public static class Factory {
+            private static org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(Factory.class);
+
+            /**
+             * static method to create the object
+             * Precondition:  If this object is an element, the current or next start element starts this object and any intervening reader events are ignorable
+             *                If this object is not an element, it is a complex type and the reader is at the event just after the outer start element
+             * Postcondition: If this object is an element, the reader is positioned at its end element
+             *                If this object is a complex type, the reader is positioned at the end element of its outer element
+             */
+            public static NfeDadosMsg parse(
+                javax.xml.stream.XMLStreamReader reader)
+                throws Exception {
+                NfeDadosMsg object = new NfeDadosMsg();
+
+                int event;
+                javax.xml.namespace.QName currentQName = null;
+                String nillableValue = null;
+                String prefix = "";
+                String namespaceuri = "";
+
+                try {
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    currentQName = reader.getName();
+
+                    if (reader.getAttributeValue(
+                                "http://www.w3.org/2001/XMLSchema-instance",
+                                "type") != null) {
+                        String fullTypeName = reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance",
+                                "type");
+
+                        if (fullTypeName != null) {
+                            String nsPrefix = null;
+
+                            if (fullTypeName.indexOf(":") > -1) {
+                                nsPrefix = fullTypeName.substring(0,
+                                        fullTypeName.indexOf(":"));
+                            }
+
+                            nsPrefix = (nsPrefix == null) ? "" : nsPrefix;
+
+                            String type = fullTypeName.substring(fullTypeName.indexOf(
+                                        ":") + 1);
+
+                            if (!"nfeDadosMsg".equals(type)) {
+                                //find namespace for the prefix
+                                String nsUri = reader.getNamespaceContext()
+                                                               .getNamespaceURI(nsPrefix);
+
+                                return (NfeDadosMsg) ExtensionMapper.getTypeObject(nsUri,
+                                    type, reader);
+                            }
+                        }
+                    }
+
+                    // Note all attributes that were handled. Used to differ normal attributes
+                    // from anyAttributes.
+                    java.util.Vector handledAttributes = new java.util.Vector();
+
+                    reader.next();
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        //use the QName from the parser as the name for the builder
+                        javax.xml.namespace.QName startQname1 = reader.getName();
+
+                        // We need to wrap the reader so that it produces a fake START_DOCUMENT event
+                        // this is needed by the builder classes
+                        org.apache.axis2.databinding.utils.NamedStaxOMBuilder builder1 =
+                            new org.apache.axis2.databinding.utils.NamedStaxOMBuilder(new org.apache.axis2.util.StreamWrapper(
+                                    reader), startQname1);
+                        object.setExtraElement(builder1.getOMElement());
+
+                        reader.next();
+                    } // End of if for expected property start element
+
+                    else {
+                        // 1 - A start element we are not expecting indicates an invalid parameter was passed
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        // 2 - A start element we are not expecting indicates a trailing invalid property
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+                } catch (javax.xml.stream.XMLStreamException e) {
+                    throw new Exception(e);
+                }
+
+                return object;
+            }
+        } //end of factory class
+    }
+
+    public static class ExtensionMapper {
+        public static Object getTypeObject(
+            String namespaceURI, String typeName,
+            javax.xml.stream.XMLStreamReader reader) throws Exception {
+            throw new org.apache.axis2.databinding.ADBException(
+                "Unsupported type " + namespaceURI + " " + typeName);
+        }
+    }
+}


### PR DESCRIPTION
[Issue #196] Corrigindo o erro 'Rejeicao: 587 (Usar somente o namespace padrao da NF-e)' retornado pela SEFAZ do MS. Gerei novo stub específico para uso em chamadas do MS.