### PR TITLE
Ajuste na url do QRCode do DF

### DIFF
--- a/src/main/resources/WebServicesNfe.ini
+++ b/src/main/resources/WebServicesNfe.ini
@@ -460,12 +460,12 @@ URL-ConsultaNFCe=www.sefaz.ce.gov.br/nfce/consulta
 
 [NFCe_DF_P]
 Usar=NFCe_SVRS_P
-URL-QRCode=http://dec.fazenda.df.gov.br/ConsultarNFCe.aspx
+URL-QRCode=https://www.fazenda.df.gov.br/nfce/qrcode
 URL-ConsultaNFCe=www.fazenda.df.gov.br/nfce/consulta
 
 [NFCe_DF_H]
 Usar=NFCe_SVRS_H
-URL-QRCode=http://dec.fazenda.df.gov.br/ConsultarNFCe.aspx
+URL-QRCode=https://www.fazenda.df.gov.br/nfce/qrcode
 URL-ConsultaNFCe=www.fazenda.df.gov.br/nfce/consulta
 
 [NFCe_ES_P]


### PR DESCRIPTION
Segue a correção da URL do QRCode para o DF - Distrito Federal

URL Errada:
https://dec.fazenda.df.gov.br/ConsultarNFCe.aspx?
p=53201223244006002072650200000226721165226720|2|1|2|3A2F6106F58278981A8FEB016635EAA80F06DEB2

URL Certa:
https://www.fazenda.df.gov.br/nfce/qrcode?
p=53201223244006002072650200000226721165226720|2|1|2|3A2F6106F58278981A8FEB016635EAA80F06DEB2