### PR TITLE
Disponibiliza Causa da Exception ao o Usuário

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/Enviar.java
+++ b/src/main/java/br/com/swconsultoria/nfe/Enviar.java
@@ -134,7 +134,7 @@ class Enviar {
             return XmlNfeUtil.xmlToObject(result.getExtraElement().toString(), TRetEnviNFe.class);
 
         } catch (RemoteException | XMLStreamException | JAXBException e) {
-            throw new NfeException(e.getMessage());
+            throw new NfeException(e.getMessage(), e);
         }
 
     }

--- a/src/main/java/br/com/swconsultoria/nfe/exception/NfeException.java
+++ b/src/main/java/br/com/swconsultoria/nfe/exception/NfeException.java
@@ -32,6 +32,17 @@ public class NfeException extends Exception {
 	}
 
 	/**
+	 * Construtor da classe.
+	 *
+	 * @param message
+	 * @param cause
+	 */
+	public NfeException(String message, Throwable cause) {
+		this(cause);
+		this.message = message;
+	}
+
+	/**
 	 * @return the message
 	 */
 	public String getMessage() {


### PR DESCRIPTION
Caso de uso:

Ao usar a `Nfe.enviarNfe()` e ocorrer uma `NfeException` pode ser necessário consultar o Status na Sefaz, porém, se a causa for um `RemoteException` não adianta consultar, pois também irá falhar, causando 2x o timeout.

Portanto, ao inserir a causa é possível algo do tipo:

```java
        Throwable throwable = e;
        for (; throwable != null; throwable = throwable.getCause()) {
            if (throwable instanceof RemoteException) {
                //trata offline
            }
        }
```
