### PR TITLE
WIP: Atualiza axis para 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.6</version>
+            <version>4.4.15</version>
         </dependency>
 
         <!--Java 11-->
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-kernel</artifactId>
-            <version>1.7.9</version>
+            <version>1.8.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>servlet-api</artifactId>
@@ -101,31 +101,31 @@
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-adb</artifactId>
-            <version>1.7.9</version>
+            <version>1.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-jaxws</artifactId>
-            <version>1.7.9</version>
+            <version>1.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-http</artifactId>
-            <version>1.7.9</version>
+            <version>1.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-local</artifactId>
-            <version>1.7.9</version>
+            <version>1.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
-            <version>1.2.22</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-kernel</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.9</version>
             <exclusions>
                 <exclusion>
                     <artifactId>servlet-api</artifactId>
@@ -101,31 +101,31 @@
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-adb</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-jaxws</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-http</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-local</artifactId>
-            <version>1.7.5</version>
+            <version>1.7.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
-            <version>1.2.20</version>
+            <version>1.2.22</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>


### PR DESCRIPTION
O axis 1.8.0 utiliza o HttpClient 4.x por padrão, ao invés do HttpClient 3
Fonte: https://axis.apache.org/axis2/java/core/release-notes/1.8.0.html

Possivelmente arruma o bug #236.