### PR TITLE
Remove uso do Charset

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/dom/ConfiguracoesNfe.java
+++ b/src/main/java/br/com/swconsultoria/nfe/dom/ConfiguracoesNfe.java
@@ -31,9 +31,6 @@ import java.util.logging.Logger;
  * @see ConfiguracoesWebNfe
  */
 public class ConfiguracoesNfe {
-    static {
-        System.setProperty("file.encoding", "UTF-8");
-    }
 
     private EstadosEnum estado;
     private AmbienteEnum ambiente;

--- a/src/main/java/br/com/swconsultoria/nfe/dom/ConfiguracoesNfe.java
+++ b/src/main/java/br/com/swconsultoria/nfe/dom/ConfiguracoesNfe.java
@@ -31,6 +31,9 @@ import java.util.logging.Logger;
  * @see ConfiguracoesWebNfe
  */
 public class ConfiguracoesNfe {
+    static {
+        System.setProperty("file.encoding", "UTF-8");
+    }
 
     private EstadosEnum estado;
     private AmbienteEnum ambiente;
@@ -72,16 +75,6 @@ public class ConfiguracoesNfe {
         configuracoesNfe.setCertificado(
                 ObjetoUtil.verifica(certificado).orElseThrow(() -> new IllegalArgumentException("Certificado não pode ser Nulo.")));
         configuracoesNfe.setPastaSchemas(pastaSchemas);
-
-        try {
-            //Setando Encoding.
-            System.setProperty("file.encoding", "UTF-8");
-            Field charset = Charset.class.getDeclaredField("defaultCharset");
-            charset.setAccessible(true);
-            charset.set(null, null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new CertificadoException("Erro ao setar Encoding.");
-        }
 
         if (Logger.getLogger("").isLoggable(Level.SEVERE)) {
             System.err.println("####################################################################");

--- a/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
@@ -16,9 +16,7 @@ import br.com.swconsultoria.nfe.schema_4.inutNFe.TInutNFe;
 import br.com.swconsultoria.nfe.schema_4.inutNFe.TProcInutNFe;
 import br.com.swconsultoria.nfe.schema_4.inutNFe.TRetInutNFe;
 import br.com.swconsultoria.nfe.schema_4.retConsSitNFe.TRetConsSitNFe;
-import com.sun.xml.bind.marshaller.CharacterEscapeHandler;
-import com.sun.xml.bind.marshaller.MinimumEscapeHandler;
-import com.sun.xml.bind.marshaller.NoEscapeHandler;
+import com.sun.xml.bind.marshaller.DumbEscapeHandler;
 
 import javax.xml.bind.*;
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -313,7 +311,9 @@ public class XmlNfeUtil {
         marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
         marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
-        marshaller.setProperty("com.sun.xml.bind.characterEscapeHandler", MinimumEscapeHandler.theInstance);
+
+        //Escape everything above the US-ASCII code range. A fallback position. Works with any JDK, any encoding.
+        marshaller.setProperty("com.sun.xml.bind.characterEscapeHandler", DumbEscapeHandler.theInstance);
 
         StringWriter sw = new StringWriter();
 

--- a/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
@@ -16,6 +16,9 @@ import br.com.swconsultoria.nfe.schema_4.inutNFe.TInutNFe;
 import br.com.swconsultoria.nfe.schema_4.inutNFe.TProcInutNFe;
 import br.com.swconsultoria.nfe.schema_4.inutNFe.TRetInutNFe;
 import br.com.swconsultoria.nfe.schema_4.retConsSitNFe.TRetConsSitNFe;
+import com.sun.xml.bind.marshaller.CharacterEscapeHandler;
+import com.sun.xml.bind.marshaller.MinimumEscapeHandler;
+import com.sun.xml.bind.marshaller.NoEscapeHandler;
 
 import javax.xml.bind.*;
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -307,20 +310,22 @@ public class XmlNfeUtil {
         assert context != null;
         Marshaller marshaller = context.createMarshaller();
 
-        marshaller.setProperty("jaxb.encoding", "Unicode");
+        marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
         marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+        marshaller.setProperty("com.sun.xml.bind.characterEscapeHandler", MinimumEscapeHandler.theInstance);
 
         StringWriter sw = new StringWriter();
 
+        sw.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         marshaller.marshal(element, sw);
-        StringBuilder xml = new StringBuilder();
-        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(sw.toString());
+
+        String xml = sw.toString();
 
         if ((obj.getClass().getSimpleName().equals(TPROCEVENTO))) {
-            return replacesNfe(xml.toString().replaceAll("procEvento", "procEventoNFe"));
+            return replacesNfe(xml.replace("procEvento", "procEventoNFe"));
         } else {
-            return replacesNfe(xml.toString());
+            return replacesNfe(xml);
         }
 
     }


### PR DESCRIPTION
Tentativa de remover o uso do Charset.

Teoricamente o `static {}` executa antes do `Charset.defaultCharset()` e quando ele executar irá retornar o que foi setado em `System.setProperty("file.encoding", "UTF-8");`