### PR TITLE
Otimiza geração do XML

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
@@ -311,16 +311,15 @@ public class XmlNfeUtil {
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
         marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
 
-        StringWriter sw = new StringWriter();
+        StringWriter sw = new StringWriter(4096);
+        sw.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
 
         marshaller.marshal(element, sw);
-        StringBuilder xml = new StringBuilder();
-        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(sw.toString());
 
         if ((obj.getClass().getSimpleName().equals(TPROCEVENTO))) {
-            return replacesNfe(xml.toString().replaceAll("procEvento", "procEventoNFe"));
+            return replacesNfe(sw.toString().replace("procEvento", "procEventoNFe"));
         } else {
-            return replacesNfe(xml.toString());
+            return replacesNfe(sw.toString());
         }
 
     }


### PR DESCRIPTION
1) Utiliza apenas o `StringWriter` pois ele já possui um `StringBuilder` interno;
2) Usa `replace` ao invés de `replaceAll`, onde o último usa regex
3) Inicializa com um buffer maior