### PR TITLE
Atualizado link de consulta NFCe em homologação para MG

### DIFF
--- a/src/main/resources/WebServicesNfe.ini
+++ b/src/main/resources/WebServicesNfe.ini
@@ -517,7 +517,7 @@ NfeStatusServico_4.00=https://hnfce.fazenda.mg.gov.br/nfce/services/NFeStatusSer
 NFeAutorizacao_4.00=https://hnfce.fazenda.mg.gov.br/nfce/services/NFeAutorizacao4
 NFeRetAutorizacao_4.00=https://hnfce.fazenda.mg.gov.br/nfce/services/NFeRetAutorizacao4
 URL-QRCode=https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml
-URL-ConsultaNFCe=http://hnfce.fazenda.mg.gov.br/portalnfce
+URL-ConsultaNFCe=https://hportalsped.fazenda.mg.gov.br/portalnfce
 
 [NFCe_MS_P]
 NFeAutorizacao_4.00=https://nfce.sefaz.ms.gov.br/ws/NFeAutorizacao4


### PR DESCRIPTION
Atualizado arquivo WebServicesNfe.ini com o novo link da consulta NFCe de MG no ambiente homologação