### PR TITLE
Ajustada busca da url de envio quando estiver em contingência

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/util/WebServiceUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/WebServiceUtil.java
@@ -89,8 +89,9 @@ public class WebServiceUtil {
                     || tipoServico.equals(ServicosEnum.MANIFESTACAO)
                     || tipoServico.equals(ServicosEnum.EPEC)) {
                 secao = config.getAmbiente().equals(AmbienteEnum.HOMOLOGACAO) ? "NFe_AN_H" : "NFe_AN_P";
-
-            } else if (config.isContigenciaSVC()) {
+            } else if (!tipoServico.equals(ServicosEnum.URL_CONSULTANFCE)
+                    && !tipoServico.equals(ServicosEnum.URL_QRCODE) 
+                    && config.isContigenciaSVC() && tipoDocumento.equals(DocumentoEnum.NFE)) {
                 // SVC-RS
                 if (config.getEstado().equals(EstadosEnum.GO) || config.getEstado().equals(EstadosEnum.AM)
                         || config.getEstado().equals(EstadosEnum.BA) || config.getEstado().equals(EstadosEnum.CE)

--- a/src/main/java/br/com/swconsultoria/nfe/util/WebServiceUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/WebServiceUtil.java
@@ -90,9 +90,6 @@ public class WebServiceUtil {
                     || tipoServico.equals(ServicosEnum.EPEC)) {
                 secao = config.getAmbiente().equals(AmbienteEnum.HOMOLOGACAO) ? "NFe_AN_H" : "NFe_AN_P";
 
-            } else if (!tipoServico.equals(ServicosEnum.URL_CONSULTANFCE)
-                    && !tipoServico.equals(ServicosEnum.URL_QRCODE) && ObjetoUtil.verifica(url).isPresent()) {
-                secao = url;
             } else if (config.isContigenciaSVC()) {
                 // SVC-RS
                 if (config.getEstado().equals(EstadosEnum.GO) || config.getEstado().equals(EstadosEnum.AM)
@@ -108,6 +105,9 @@ public class WebServiceUtil {
                     secao = tipoDocumento.getTipo() + "_SVC-AN_"
                             + (config.getAmbiente().equals(AmbienteEnum.HOMOLOGACAO) ? "H" : "P");
                 }
+            }else if (!tipoServico.equals(ServicosEnum.URL_CONSULTANFCE)
+                    && !tipoServico.equals(ServicosEnum.URL_QRCODE) && ObjetoUtil.verifica(url).isPresent()) {
+                secao = url;
             }
 
             url = ini.get(secao, tipoServico.getServico().toLowerCase());


### PR DESCRIPTION
Apenas inverti a ordem dos ifs, para que antes de verificar se encontrou a url, verifique se esta contingência.

Assim é como estava antes do commit, a lib sempre encontrava a url, com isso não chegava na verificação da contingência.
![Capturar](https://github.com/Samuel-Oliveira/Java_NFe/assets/37849018/bc297a37-ccb4-46c3-b684-dda52f3a4149)

Testei a implementação com certificado de SC, como ativei contingência usou o ambiente nacional para autorizar.

Lembrando que esta contingência é apenas para quando for uma NF-e e tpEmissao=6 ou 7.

