### PR TITLE
feat: implementação NT2023.004

### DIFF
--- a/schemas/leiauteNFe_v4.00.xsd
+++ b/schemas/leiauteNFe_v4.00.xsd
@@ -5680,6 +5680,11 @@ Substituição Tributaria;</xs:documentation>
 														<xs:documentation>Valor do Pagamento. Esta tag poderá ser omitida quando a tag tPag=90 (Sem Pagamento), caso contrário deverá ser preenchida.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
+												<xs:element name="dPag" type="TData">
+													<xs:annotation>
+														<xs:documentation>Data de pagamento do Documento de Arrecadação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
 												<xs:element name="card" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>Grupo de Cartões</xs:documentation>
@@ -5718,12 +5723,12 @@ Substituição Tributaria;</xs:documentation>
 															</xs:element>
 															<xs:element name="cAut" minOccurs="0">
 																<xs:annotation>
-																	<xs:documentation>Número de autorização da operação cartão de crédito/débito</xs:documentation>
+																	<xs:documentation>Número de autorização da operação cartão de crédito/débito/pix/boletos</xs:documentation>
 																</xs:annotation>
 																<xs:simpleType>
 																	<xs:restriction base="TString">
 																		<xs:minLength value="1"/>
-																		<xs:maxLength value="20"/>
+																		<xs:maxLength value="128"/>
 																	</xs:restriction>
 																</xs:simpleType>
 															</xs:element>

--- a/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TNFe.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TNFe.java
@@ -35576,6 +35576,7 @@ public class TNFe {
                 "tPag",
                 "xPag",
                 "vPag",
+                "dPag",
                 "card"
             })
             public static class DetPag {
@@ -35589,8 +35590,22 @@ public class TNFe {
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe", required = true)
                 protected String vPag;
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
+                protected String dPag;
+                @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
                 protected TNFe.InfNFe.Pag.DetPag.Card card;
 
+
+                /**
+                 * Obtém o valor da propriedade dPag.
+                 *
+                 * @return
+                 *     possible object is
+                 *     {@link String }
+                 *
+                 */
+                public String getDPag() {
+                    return  dPag;
+                }
                 /**
                  * Obtém o valor da propriedade indPag.
                  * 
@@ -35637,6 +35652,18 @@ public class TNFe {
                  */
                 public void setTPag(String value) {
                     this.tPag = value;
+                }
+
+                /**
+                 * Define o valor da propriedade dPag.
+                 *
+                 * @param value
+                 *     allowed object is
+                 *     {@link String }
+                 *
+                 */
+                public void setDPag(String value) {
+                    this.dPag = value;
                 }
 
                 /**


### PR DESCRIPTION
Ajustes de alguns campos referentes NT2023.004

- Inclusão YA dPag_YA03a
- Ajuste tamanho campo cAut_YA07 para 1-128 para envios de informações de autorização de cartões, PIX, boletos e outros pagamentos eletrônicos.

![image](https://github.com/Samuel-Oliveira/Java_NFe/assets/68030796/f6e6c487-ca19-488e-ae6d-44d563de16b8)
![image](https://github.com/Samuel-Oliveira/Java_NFe/assets/68030796/a5b62dbd-0a75-41c5-a918-80125e2cd7b0)
