### PR TITLE
Ajustes NT2023.004

### DIFF
--- a/schemas/consCad_v2.00.xsd
+++ b/schemas/consCad_v2.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteConsultaCadastro_v2.00.xsd"/>
 	<xs:element name="ConsCad" type="TConsCad">
 		<xs:annotation>

--- a/schemas/consReciNFe_v4.00.xsd
+++ b/schemas/consReciNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="consReciNFe" type="TConsReciNFe">
 		<xs:annotation>

--- a/schemas/consStatServ_v4.00.xsd
+++ b/schemas/consStatServ_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteConsStatServ_v4.00.xsd"/>
 	<xs:element name="consStatServ" type="TConsStatServ">
 		<xs:annotation>

--- a/schemas/enviNFe_v4.00.xsd
+++ b/schemas/enviNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="enviNFe" type="TEnviNFe">
 		<xs:annotation>

--- a/schemas/inutNFe_v4.00.xsd
+++ b/schemas/inutNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
 	<xs:element name="inutNFe" type="TInutNFe">
 		<xs:annotation>

--- a/schemas/leiauteConsStatServ_v4.00.xsd
+++ b/schemas/leiauteConsStatServ_v4.00.xsd
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--  PL_006f versao com correcoes no xServ para tornar a literal STATUS obrigatoria 21/05/2010 -->
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		   targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-		   attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
 	<xs:complexType name="TConsStatServ">
 		<xs:annotation>

--- a/schemas/leiauteConsultaCadastro_v2.00.xsd
+++ b/schemas/leiauteConsultaCadastro_v2.00.xsd
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--  PL_006f versao com correcoes no xServ para tornar a literal CONS-CAD obrigatoria 21/05/2010 -->
 <!--  PL_006c versao com correcoes 24/12/2009 -->
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		   targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-		   attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
 	<xs:complexType name="TConsCad">
 		<xs:annotation>

--- a/schemas/leiauteNFe_v4.00.xsd
+++ b/schemas/leiauteNFe_v4.00.xsd
@@ -5680,6 +5680,11 @@ Substituição Tributaria;</xs:documentation>
 														<xs:documentation>Valor do Pagamento. Esta tag poderá ser omitida quando a tag tPag=90 (Sem Pagamento), caso contrário deverá ser preenchida.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
+												<xs:element name="dPag" type="TData">
+													<xs:annotation>
+														<xs:documentation>Data de pagamento do Documento de Arrecadação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
 												<xs:element name="card" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>Grupo de Cartões</xs:documentation>
@@ -5718,12 +5723,12 @@ Substituição Tributaria;</xs:documentation>
 															</xs:element>
 															<xs:element name="cAut" minOccurs="0">
 																<xs:annotation>
-																	<xs:documentation>Número de autorização da operação cartão de crédito/débito</xs:documentation>
+																	<xs:documentation>Número de autorização da operação cartão de crédito/débito/pix/boletos</xs:documentation>
 																</xs:annotation>
 																<xs:simpleType>
 																	<xs:restriction base="TString">
 																		<xs:minLength value="1"/>
-																		<xs:maxLength value="20"/>
+																		<xs:maxLength value="128"/>
 																	</xs:restriction>
 																</xs:simpleType>
 															</xs:element>

--- a/schemas/leiauteNFe_v4.00.xsd
+++ b/schemas/leiauteNFe_v4.00.xsd
@@ -14,9 +14,10 @@
 <!-- PL_009-v4b  implementado alterações da NT 2020.006 -->
 <!-- PL_009-v5a  implementado alterações da NT  -->
 <!-- PL_009k_NT2023_001_v100 implementado alterações da NT 2023.001  -->
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-		   xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe"
-		   elementFormDefault="qualified" attributeFormDefault="unqualified">
+<!-- PL_009l_NT2023_002_v100 - Alteração de Schema para evitar caracteres inválidos  -->
+<!-- PL_009m_NT2019_001_v155 - Inclusão de campos para Crédito Presumido e Redução da base de cálculo -->
+<!-- PL_009m_NT2023_004_v101 - Informações de Pagamentos e Outros -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:editix="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
 	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
 	<xs:complexType name="TNFe">
@@ -279,7 +280,7 @@ para tpEmis diferente de 1</xs:documentation>
 											</xs:simpleType>
 										</xs:element>
 									</xs:sequence>
-									<xs:element name="NFref" minOccurs="0" maxOccurs="unbounded">
+									<xs:element name="NFref" minOccurs="0" maxOccurs="999">
 										<xs:annotation>
 											<xs:documentation>Grupo de infromações da NF referenciada</xs:documentation>
 										</xs:annotation>
@@ -915,6 +916,29 @@ Formato ”CFOP9999”.</xs:documentation>
 														</xs:restriction>
 													</xs:simpleType>
 												</xs:element>
+												<xs:sequence minOccurs="0" maxOccurs="4">
+													<xs:element name="cCredPresumido">
+														<xs:annotation>
+															<xs:documentation>Código de Benefício Fiscal de Crédito Presumido na UF aplicado ao item</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="pCredPresumido" type="TDec_0302a04">
+														<xs:annotation>
+															<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="vCredPresumido" type="TDec_1302">
+														<xs:annotation>
+															<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
 												<xs:element name="EXTIPI" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>Código EX TIPI (3 posições)</xs:documentation>
@@ -1049,7 +1073,7 @@ Formato ”CFOP9999”.</xs:documentation>
 														<xs:sequence>
 															<xs:element name="nDI">
 																<xs:annotation>
-																	<xs:documentation>Numero do Documento de Importação DI/DSI/DA/DRI-E (DI/DSI/DA/DRI-E) (NT2011/004)</xs:documentation>
+																	<xs:documentation>Número do Documento de Importação (DI, DSI, DIRE, DUImp) (NT2011/004)</xs:documentation>
 																</xs:annotation>
 																<xs:simpleType>
 																	<xs:restriction base="TString">
@@ -1086,7 +1110,7 @@ Formato ”CFOP9999”.</xs:documentation>
 															</xs:element>
 															<xs:element name="tpViaTransp">
 																<xs:annotation>
-																	<xs:documentation>Via de transporte internacional informada na DI
+																	<xs:documentation>Via de transporte internacional informada na DI ou na Declaração Única de Importação (DUImp):
 																	1-Maritima;2-Fluvial;3-Lacustre;4-Aerea;5-Postal;6-Ferroviaria;7-Rodoviaria;8-Conduto;9-Meios Proprios;10-Entrada/Saida Ficta;
 																	11-Courier;12-Em maos;13-Por reboque.</xs:documentation>
 																</xs:annotation>
@@ -1128,11 +1152,18 @@ Formato ”CFOP9999”.</xs:documentation>
 																	</xs:restriction>
 																</xs:simpleType>
 															</xs:element>
-															<xs:element name="CNPJ" type="TCnpj" minOccurs="0">
-																<xs:annotation>
-																	<xs:documentation>CNPJ do adquirente ou do encomendante</xs:documentation>
-																</xs:annotation>
-															</xs:element>
+															<xs:choice minOccurs="0">
+																<xs:element name="CNPJ" type="TCnpj">
+																	<xs:annotation>
+																		<xs:documentation>CNPJ do adquirente ou do encomendante</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CPF" type="TCpf">
+																	<xs:annotation>
+																		<xs:documentation>CPF do adquirente ou do encomendante</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:choice>
 															<xs:element name="UFTerceiro" type="TUfEmi" minOccurs="0">
 																<xs:annotation>
 																	<xs:documentation>Sigla da UF do adquirente ou do encomendante</xs:documentation>
@@ -1168,7 +1199,7 @@ Formato ”CFOP9999”.</xs:documentation>
 																		</xs:element>
 																		<xs:element name="nSeqAdic">
 																			<xs:annotation>
-																				<xs:documentation>Número seqüencial do item dentro da Adição</xs:documentation>
+																				<xs:documentation>Número seqüencial do item</xs:documentation>
 																			</xs:annotation>
 																			<xs:simpleType>
 																				<xs:restriction base="xs:string">
@@ -1190,7 +1221,7 @@ Formato ”CFOP9999”.</xs:documentation>
 																		</xs:element>
 																		<xs:element name="vDescDI" type="TDec_1302Opc" minOccurs="0">
 																			<xs:annotation>
-																				<xs:documentation>Valor do desconto do item da DI – adição</xs:documentation>
+																				<xs:documentation>Valor do desconto do item</xs:documentation>
 																			</xs:annotation>
 																		</xs:element>
 																		<xs:element name="nDraw" minOccurs="0">
@@ -1295,7 +1326,7 @@ Formato ”CFOP9999”.</xs:documentation>
 																	<xs:documentation>Número do lote do produto.</xs:documentation>
 																</xs:annotation>
 																<xs:simpleType>
-																	<xs:restriction base="xs:string">
+																	<xs:restriction base="TString">
 																		<xs:minLength value="1"/>
 																		<xs:maxLength value="20"/>
 																	</xs:restriction>
@@ -1805,7 +1836,7 @@ N-NormalVIN</xs:documentation>
 																		<xs:documentation>Descrição do Produto conforme ANP. Utilizar a descrição de produtos do Sistema de Informações de Movimentação de Produtos - SIMP (http://www.anp.gov.br/simp/).</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
-																		<xs:restriction base="xs:string">
+																		<xs:restriction base="TString">
 																			<xs:minLength value="2"/>
 																			<xs:maxLength value="95"/>
 																		</xs:restriction>
@@ -2467,6 +2498,20 @@ ambiente.</xs:documentation>
 																							</xs:restriction>
 																						</xs:simpleType>
 																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																				</xs:sequence>
 																			</xs:sequence>
 																		</xs:complexType>
@@ -2585,6 +2630,20 @@ ambiente.</xs:documentation>
 																							</xs:restriction>
 																						</xs:simpleType>
 																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																				</xs:sequence>
 																			</xs:sequence>
 																		</xs:complexType>
@@ -2663,15 +2722,27 @@ Informar o motivo da desoneração:
 																							</xs:restriction>
 																						</xs:simpleType>
 																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																				</xs:sequence>
 																			</xs:sequence>
 																		</xs:complexType>
 																	</xs:element>
 																	<xs:element name="ICMS51">
 																		<xs:annotation>
-																			<xs:documentation>Tributção pelo ICMS
-51 - Diferimento
-A exigência do preenchimento das informações do ICMS diferido fica à critério de cada UF.</xs:documentation>
+																			<xs:documentation>Tributção pelo ICMS 51 - Diferimento. A exigência do preenchimento das informações do ICMS diferido fica à critério de cada UF.</xs:documentation>
 																		</xs:annotation>
 																		<xs:complexType>
 																			<xs:sequence>
@@ -2716,6 +2787,17 @@ A exigência do preenchimento das informações do ICMS diferido fica à critér
 																					<xs:annotation>
 																						<xs:documentation>Percentual de redução da BC</xs:documentation>
 																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="cBenefRBC" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																						</xs:restriction>
+																					</xs:simpleType>
 																				</xs:element>
 																				<xs:element name="vBC" type="TDec_1302" minOccurs="0">
 																					<xs:annotation>
@@ -3153,6 +3235,20 @@ A exigência do preenchimento das informações do ICMS diferido fica à critér
 																							</xs:restriction>
 																						</xs:simpleType>
 																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																				</xs:sequence>
 																				<xs:sequence minOccurs="0">
 																					<xs:element name="vICMSSTDeson" type="TDec_1302">
@@ -3347,6 +3443,20 @@ A exigência do preenchimento das informações do ICMS diferido fica à critér
 																								<xs:enumeration value="3"/>
 																								<xs:enumeration value="9"/>
 																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
 																							</xs:restriction>
 																						</xs:simpleType>
 																					</xs:element>
@@ -4240,7 +4350,7 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																			<xs:documentation>Código do serviço prestado dentro do município</xs:documentation>
 																		</xs:annotation>
 																		<xs:simpleType>
-																			<xs:restriction base="xs:string">
+																			<xs:restriction base="TString">
 																				<xs:whiteSpace value="preserve"/>
 																				<xs:minLength value="1"/>
 																				<xs:maxLength value="20"/>
@@ -4268,7 +4378,7 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																			<xs:documentation>Número do Processo administrativo ou judicial de suspenção do processo</xs:documentation>
 																		</xs:annotation>
 																		<xs:simpleType>
-																			<xs:restriction base="xs:string">
+																			<xs:restriction base="TString">
 																				<xs:whiteSpace value="preserve"/>
 																				<xs:minLength value="1"/>
 																				<xs:maxLength value="30"/>
@@ -5472,7 +5582,7 @@ Substituição Tributaria;</xs:documentation>
 											</xs:simpleType>
 										</xs:element>
 									</xs:choice>
-									<xs:element name="vol" minOccurs="0" maxOccurs="unbounded">
+									<xs:element name="vol" minOccurs="0" maxOccurs="5000">
 										<xs:annotation>
 											<xs:documentation>Dados dos volumes</xs:documentation>
 										</xs:annotation>
@@ -5532,7 +5642,7 @@ Substituição Tributaria;</xs:documentation>
 														<xs:documentation>Peso bruto (em kg)</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element name="lacres" minOccurs="0" maxOccurs="unbounded">
+												<xs:element name="lacres" minOccurs="0" maxOccurs="5000">
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element name="nLacre">
@@ -5680,22 +5790,34 @@ Substituição Tributaria;</xs:documentation>
 														<xs:documentation>Valor do Pagamento. Esta tag poderá ser omitida quando a tag tPag=90 (Sem Pagamento), caso contrário deverá ser preenchida.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element name="dPag" type="TData">
+												<xs:element name="dPag" type="TData" minOccurs="0">
 													<xs:annotation>
-														<xs:documentation>Data de pagamento do Documento de Arrecadação</xs:documentation>
+														<xs:documentation>Data do Pagamento</xs:documentation>
 													</xs:annotation>
 												</xs:element>
+												<xs:sequence minOccurs="0">
+													<xs:element name="CNPJPag" type="TCnpj">
+														<xs:annotation>
+															<xs:documentation>CNPJ transacional do pagamento - Preencher informando o CNPJ do estabelecimento onde o pagamento foi processado/transacionado/recebido quando a emissão do documento fiscal ocorrer em estabelecimento distinto</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="UFPag" type="TUfEmi">
+														<xs:annotation>
+															<xs:documentation>UF do CNPJ do estabelecimento onde o pagamento foi processado/transacionado/recebido.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
 												<xs:element name="card" minOccurs="0">
 													<xs:annotation>
-														<xs:documentation>Grupo de Cartões</xs:documentation>
+														<xs:documentation>Grupo de Cartões, PIX, Boletos e outros Pagamentos Eletrônicos</xs:documentation>
 													</xs:annotation>
 													<xs:complexType>
 														<xs:sequence>
 															<xs:element name="tpIntegra">
 																<xs:annotation>
-																	<xs:documentation>Tipo de Integração do processo de pagamento com o sistema de automação da empresa/ 
-																1=Pagamento integrado com o sistema de automação da empresa Ex. equipamento TEF , Comercio Eletronico
-																2=Pagamento não integrado com o sistema de automação da empresa Ex: equipamento POS</xs:documentation>
+																	<xs:documentation>Tipo de Integração do processo de pagamento com o sistema de automação da empresa:
+1 - Pagamento integrado com o sistema de automação da empresa (Ex.: equipamento TEF, Comércio Eletrônico, POS Integrado);
+2 - Pagamento não integrado com o sistema de automação da empresa (Ex.: equipamento POS Simples).</xs:documentation>
 																</xs:annotation>
 																<xs:simpleType>
 																	<xs:restriction base="xs:string">
@@ -5723,12 +5845,28 @@ Substituição Tributaria;</xs:documentation>
 															</xs:element>
 															<xs:element name="cAut" minOccurs="0">
 																<xs:annotation>
-																	<xs:documentation>Número de autorização da operação cartão de crédito/débito/pix/boletos</xs:documentation>
+																	<xs:documentation>Número de autorização da operação com cartões, PIX, boletos e outros pagamentos eletrônicos</xs:documentation>
 																</xs:annotation>
 																<xs:simpleType>
 																	<xs:restriction base="TString">
 																		<xs:minLength value="1"/>
 																		<xs:maxLength value="128"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJReceb" type="TCnpj" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>CNPJ do beneficiário do pagamento</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="idTermPag" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Identificador do terminal de pagamento</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="40"/>
 																	</xs:restriction>
 																</xs:simpleType>
 															</xs:element>
@@ -5878,7 +6016,8 @@ concessório</xs:documentation>
 1 - Justiça Federal;
 2 - Justiça Estadual;
 3 - Secex/RFB;
-9 - Outros</xs:documentation>
+4 - CONFAZ;
+9 - Outros.</xs:documentation>
 													</xs:annotation>
 													<xs:simpleType>
 														<xs:restriction base="xs:string">
@@ -5887,6 +6026,7 @@ concessório</xs:documentation>
 															<xs:enumeration value="1"/>
 															<xs:enumeration value="2"/>
 															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
 															<xs:enumeration value="9"/>
 														</xs:restriction>
 													</xs:simpleType>
@@ -5896,9 +6036,11 @@ concessório</xs:documentation>
 														<xs:documentation>Tipo do ato concessório
 														Para origem do Processo na SEFAZ (indProc=0), informar o
 tipo de ato concessório:
-08=Termo de Acordo;
-10=Regime Especial;
-12=Autorização específica;</xs:documentation>
+08 - Termo de Acordo;
+10 - Regime Especial;
+12 - Autorização específica;
+14 - Ajuste SINIEF;
+15 - Convênio ICMS.</xs:documentation>
 													</xs:annotation>
 													<xs:simpleType>
 														<xs:restriction base="xs:string">
@@ -5906,6 +6048,8 @@ tipo de ato concessório:
 															<xs:enumeration value="08"/>
 															<xs:enumeration value="10"/>
 															<xs:enumeration value="12"/>
+															<xs:enumeration value="14"/>
+															<xs:enumeration value="15"/>
 														</xs:restriction>
 													</xs:simpleType>
 												</xs:element>
@@ -6124,9 +6268,9 @@ tipo de ato concessório:
 											<xs:documentation>Solicitação do pedido de emissão da NFF</xs:documentation>
 										</xs:annotation>
 										<xs:simpleType>
-											<xs:restriction base="xs:string">
+											<xs:restriction base="TString">
 												<xs:minLength value="2"/>
-												<xs:maxLength value="2000"/>
+												<xs:maxLength value="5000"/>
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:element>
@@ -6179,7 +6323,7 @@ tipo de ato concessório:
 								<xs:documentation>Informar a URL da &quot;Consulta por chave de acesso da NFC-e&quot;. A mesma URL que deve estar informada no DANFE NFC-e para consulta por chave de acesso.</xs:documentation>
 							</xs:annotation>
 							<xs:simpleType>
-								<xs:restriction base="xs:string">
+								<xs:restriction base="TString">
 									<xs:minLength value="21"/>
 									<xs:maxLength value="85"/>
 								</xs:restriction>

--- a/schemas/nfe_v4.00.xsd
+++ b/schemas/nfe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="NFe" type="TNFe">
 		<xs:annotation>

--- a/schemas/procInutNFe_v4.00.xsd
+++ b/schemas/procInutNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
 	<xs:element name="ProcInutNFe" type="TProcInutNFe">
 		<xs:annotation>

--- a/schemas/procNFe_v4.00.xsd
+++ b/schemas/procNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="nfeProc" type="TNfeProc">
 		<xs:annotation>

--- a/schemas/retConsCad_v2.00.xsd
+++ b/schemas/retConsCad_v2.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteConsultaCadastro_v2.00.xsd"/>
 	<xs:element name="retConsCad" type="TRetConsCad">
 		<xs:annotation>

--- a/schemas/retConsReciNFe_v4.00.xsd
+++ b/schemas/retConsReciNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="retConsReciNFe" type="TRetConsReciNFe">
 		<xs:annotation>

--- a/schemas/retConsSitNFe_v4.00.xsd
+++ b/schemas/retConsSitNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteConsSitNFe_v4.00.xsd"/>
 	<xs:element name="retConsSitNFe" type="TRetConsSitNFe">
 		<xs:annotation>

--- a/schemas/retConsStatServ_v4.00.xsd
+++ b/schemas/retConsStatServ_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteConsStatServ_v4.00.xsd"/>
 	<xs:element name="retConsStatServ" type="TRetConsStatServ">
 		<xs:annotation>

--- a/schemas/retEnviNFe_v4.00.xsd
+++ b/schemas/retEnviNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="retEnviNFe" type="TRetEnviNFe">
 		<xs:annotation>

--- a/schemas/retInutNFe_v4.00.xsd
+++ b/schemas/retInutNFe_v4.00.xsd
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified"
-           attributeFormDefault="unqualified">
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
 	<xs:element name="retInutNFe" type="TRetInutNFe">
 		<xs:annotation>

--- a/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TNFe.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TNFe.java
@@ -35577,6 +35577,8 @@ public class TNFe {
                 "xPag",
                 "vPag",
                 "dPag",
+                "CNPJPag",
+                "UFPag",
                 "card"
             })
             public static class DetPag {
@@ -35590,10 +35592,37 @@ public class TNFe {
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe", required = true)
                 protected String vPag;
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
+                protected String CNPJPag;
+                @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
+                protected String UFPag;
+                @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
                 protected String dPag;
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
                 protected TNFe.InfNFe.Pag.DetPag.Card card;
 
+                /**
+                 * Obtém o valor da propriedade CNPJPag.
+                 *
+                 * @return
+                 *     possible object is
+                 *     {@link String }
+                 *
+                 */
+                public String getCNPJPag(){
+                    return CNPJPag;
+                }
+
+                /**
+                 * Obtém o valor da propriedade UFPag.
+                 *
+                 * @return
+                 *     possible object is
+                 *     {@link String }
+                 *
+                 */
+                public String getUFPag(){
+                    return UFPag;
+                }
 
                 /**
                  * Obtém o valor da propriedade dPag.
@@ -35628,6 +35657,30 @@ public class TNFe {
                  */
                 public void setIndPag(String value) {
                     this.indPag = value;
+                }
+
+                /**
+                 * Define o valor da propriedade CNPJPag.
+                 *
+                 * @param value
+                 *     allowed object is
+                 *     {@link String }
+                 *
+                 */
+                public void setCNPJPag(String value) {
+                    this.CNPJPag = value;
+                }
+
+                /**
+                 * Define o valor da propriedade UFPag.
+                 *
+                 * @param value
+                 *     allowed object is
+                 *     {@link String }
+                 *
+                 */
+                public void setUFPag(String value) {
+                    this.UFPag = value;
                 }
 
                 /**

--- a/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TNFe.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TNFe.java
@@ -35576,6 +35576,7 @@ public class TNFe {
                 "tPag",
                 "xPag",
                 "vPag",
+                "dPag",
                 "card"
             })
             public static class DetPag {
@@ -35589,8 +35590,22 @@ public class TNFe {
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe", required = true)
                 protected String vPag;
                 @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
+                protected String dPag;
+                @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
                 protected TNFe.InfNFe.Pag.DetPag.Card card;
 
+
+                /**
+                 * Obtém o valor da propriedade dPag.
+                 *
+                 * @return
+                 *     possible object is
+                 *     {@link String }
+                 *
+                 */
+                public String getDPag() {
+                    return  dPag;
+                }
                 /**
                  * Obtém o valor da propriedade indPag.
                  * 
@@ -35637,6 +35652,18 @@ public class TNFe {
                  */
                 public void setTPag(String value) {
                     this.tPag = value;
+                }
+
+                /**
+                 * Define o valor da propriedade dPag.
+                 *
+                 * @param value
+                 *     allowed object is
+                 *     {@link String }
+                 *
+                 */
+                public void setDPag(String value) {
+                    this.dPag = value;
                 }
 
                 /**


### PR DESCRIPTION
Atualização schemas de acordo com o disponibilizado no www.nfe.fazenda.gov.br

Implementação NT_2023.004 com os novos campos DPag, CNPJPag e UFPag

Atualização cAut para 1-128 caracteres para suporter informações de autorização de cartões, pix, boletos e outros meios eletronicos.

#271 

![image](https://github.com/Samuel-Oliveira/Java_NFe/assets/68030796/bbed69ce-9cde-4115-b0b1-a857a37c8913)

![image](https://github.com/Samuel-Oliveira/Java_NFe/assets/68030796/cb89df8f-5bb8-47f0-a631-6a0d2fa9a615)

![image](https://github.com/Samuel-Oliveira/Java_NFe/assets/68030796/b1efdff3-3f6a-4977-9392-2202dc038d21)

