### PR TITLE
Ajusta e move função geraHashCSRT

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/util/NFCeUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/NFCeUtil.java
@@ -1,8 +1,9 @@
 package br.com.swconsultoria.nfe.util;
 
+import java.security.InvalidParameterException;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;  
-  
+import java.security.NoSuchAlgorithmException;
+
 /** 
 * 
 * @author Samuel Oliveira
@@ -56,6 +57,26 @@ public class NFCeUtil {
         String cHashQRCode = getHexa(getHash(value.toString() + CSC)).toUpperCase();
 
         return urlConsulta + "?p=" + value + "|" + cHashQRCode;
+    }
+
+    /**
+     *
+     * Função responsável por gerar o hashCSRT conforme definições da NT2018.005 v1.40.
+     *
+     * @param chave Chave da nota fiscal com 44 caracteres.
+     * @param csrt Token/Código de Segurança do Responsável Técnico, fornecido pela Sefaz de da estado.
+     * @return bytes conforme definição da NF2018.005 v1.40 sem fazer encode em base64.
+     *         Isso porque já será feito ao gerar o xml devido ao tipo no XSD ser xs:base64Binary.
+     * @throws NoSuchAlgorithmException caso não encontre suporte para SHA-1.
+     */
+    public static byte[] geraHashCSRT(String chave, String csrt) throws NoSuchAlgorithmException {
+        ObjetoUtil.verifica(chave).orElseThrow(() -> new InvalidParameterException("Chave não deve ser nula ou vazia"));
+        ObjetoUtil.verifica(csrt).orElseThrow(() -> new InvalidParameterException("CSRT não deve ser nulo ou vazio"));
+        if (chave.length() != 44) {
+            throw new InvalidParameterException("Chave deve conter 44 caracteres.");
+        }
+
+        return getHash(csrt + chave);
     }
 
  

--- a/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
+++ b/src/main/java/br/com/swconsultoria/nfe/util/XmlNfeUtil.java
@@ -30,12 +30,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.InvalidParameterException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Base64;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.StringJoiner;
@@ -425,17 +421,5 @@ public class XmlNfeUtil {
             log.warning(e.getMessage());
         }
         return null;
-    }
-
-    public static byte[] geraHashCSRT(String chave, String csrt) throws NoSuchAlgorithmException {
-
-        ObjetoUtil.verifica(chave).orElseThrow(() -> new InvalidParameterException("Chave não deve ser nula ou vazia"));
-        ObjetoUtil.verifica(csrt).orElseThrow(() -> new InvalidParameterException("CSRT não deve ser nulo ou vazio"));
-        if (chave.length() != 44) {
-            throw new InvalidParameterException("Chave deve conter 44 caracteres.");
-        }
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
-        md.update((csrt + chave).getBytes());
-        return Base64.getEncoder().encode(md.digest());
     }
 }

--- a/src/test/java/br/com/swconsultoria/nfe/util/NFCeUtilTest.java
+++ b/src/test/java/br/com/swconsultoria/nfe/util/NFCeUtilTest.java
@@ -1,0 +1,52 @@
+package br.com.swconsultoria.nfe.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class NFCeUtilTest {
+
+    @Test
+    void geraHashCSRTSucesso() throws NoSuchAlgorithmException {
+        String chave = "41180678393592000146558900000006041028190697";
+        String csrt = "G8063VRTNDMO886SFNK5LDUDEI24XJ22YIPO";
+
+        assertArrayEquals("aWv6LeEM4X6u4+qBI2OYZ8grigw=".getBytes(StandardCharsets.UTF_8), geraHashCSRTBase64(chave, csrt));
+    }
+
+    @Test
+    void geraHashCSRTParametrosInvalidos() {
+        String chave = "41180678393592000146558900000006041028190697";
+        String csrt = "G8063VRTNDMO886SFNK5LDUDEI24XJ22YIPO";
+
+        //Chave Nula
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, ()
+                -> geraHashCSRTBase64(null, csrt)
+        );
+        assertEquals(exception.getMessage(), "Chave não deve ser nula ou vazia");
+
+        //Chave Com menos Caracteres
+        exception = assertThrows(IllegalArgumentException.class, ()
+                -> geraHashCSRTBase64("123", csrt)
+        );
+        assertEquals(exception.getMessage(), "Chave deve conter 44 caracteres.");
+
+        //CSRC Vazio
+        exception = assertThrows(IllegalArgumentException.class, ()
+                -> geraHashCSRTBase64(chave, "")
+        );
+        assertEquals(exception.getMessage(), "CSRT não deve ser nulo ou vazio");
+    }
+
+    private byte[] geraHashCSRTBase64(String chave, String csrt) throws NoSuchAlgorithmException {
+        //O XSD é xs:base64Binary e já faz o base64, aqui é uma "simulação" para os testes
+        return Base64.getEncoder().encode(NFCeUtil.geraHashCSRT(chave, csrt));
+    }
+
+}

--- a/src/test/java/br/com/swconsultoria/nfe/util/XmlNfeUtilTest.java
+++ b/src/test/java/br/com/swconsultoria/nfe/util/XmlNfeUtilTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -57,36 +55,5 @@ class XmlNfeUtilTest {
         assertEquals(exception.getMessage(), "Arquivo xml não pode ser nulo/vazio.");
     }
 
-    @Test
-    void geraHashCSRTSucesso() throws NoSuchAlgorithmException {
-        String chave = "41180678393592000146558900000006041028190697";
-        String csrt = "G8063VRTNDMO886SFNK5LDUDEI24XJ22YIPO";
-
-        assertArrayEquals("aWv6LeEM4X6u4+qBI2OYZ8grigw=".getBytes(StandardCharsets.UTF_8), XmlNfeUtil.geraHashCSRT(chave, csrt));
-    }
-
-    @Test
-    void geraHashCSRTParametrosInvalidos() {
-        String chave = "41180678393592000146558900000006041028190697";
-        String csrt = "G8063VRTNDMO886SFNK5LDUDEI24XJ22YIPO";
-
-        //Chave Nula
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, ()
-                -> XmlNfeUtil.geraHashCSRT(null, csrt)
-        );
-        assertEquals(exception.getMessage(), "Chave não deve ser nula ou vazia");
-
-        //Chave Com menos Caracteres
-        exception = assertThrows(IllegalArgumentException.class, ()
-                -> XmlNfeUtil.geraHashCSRT("123", csrt)
-        );
-        assertEquals(exception.getMessage(), "Chave deve conter 44 caracteres.");
-
-        //CSRC Vazio
-        exception = assertThrows(IllegalArgumentException.class, ()
-                -> XmlNfeUtil.geraHashCSRT(chave, "")
-        );
-        assertEquals(exception.getMessage(), "CSRT não deve ser nulo ou vazio");
-    }
 
 }


### PR DESCRIPTION
- Move `geraHashCSRT` de `XmlNfeUtil` para `NFCeUtil`
- Ajusta para gerar os bytes conforme definição da NF2018.005 v1.40 sem fazer encode em base64. Isso porque já será feito ao gerar o xml devido ao tipo no XSD ser xs:base64Binary.