### PR TITLE
Fix: SSL Handshake Error in Multithreading Mode (ConsultaTributacao)

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/ConsultaTributacao.java
+++ b/src/main/java/br/com/swconsultoria/nfe/ConsultaTributacao.java
@@ -507,7 +507,18 @@ public class ConsultaTributacao {
     }
 
     private static String executeRequestWithHttpClient(HttpClient httpClient, String url) throws IOException {
-        GetMethod getMethod = new GetMethod(url);
+        String uri = url;
+        if (httpClient.getHostConfiguration().getProtocol() != null) {
+            try {
+                URL u = new URL(url);
+                httpClient.getHostConfiguration().setHost(u.getHost(), u.getPort(), httpClient.getHostConfiguration().getProtocol());
+                uri = u.getFile();
+            } catch (Exception e) {
+                log.warning("[ConsultaTributacao] Erro ao processar URL para modo multithreading: " + e.getMessage());
+            }
+        }
+
+        GetMethod getMethod = new GetMethod(uri);
 
         try {
             getMethod.setRequestHeader("Accept", "application/json");

--- a/src/main/java/br/com/swconsultoria/nfe/ConsultaTributacao.java
+++ b/src/main/java/br/com/swconsultoria/nfe/ConsultaTributacao.java
@@ -134,7 +134,7 @@ public class ConsultaTributacao {
         try {
             HttpClient httpClient = createHttpClient(config, certificado, url);
             if (httpClient != null) {
-                return executeRequestWithHttpClient(httpClient, url);
+                return executeRequestWithHttpClient(httpClient, url, certificado);
             }
         } catch (CertificadoException e) {
             log.warning("[ConsultaTributacao] Falha ao criar HttpClient, tentando fallback: " + e.getMessage());
@@ -506,15 +506,17 @@ public class ConsultaTributacao {
         }
     }
 
-    private static String executeRequestWithHttpClient(HttpClient httpClient, String url) throws IOException {
+    private static String executeRequestWithHttpClient(HttpClient httpClient, String url, Certificado certificado) throws IOException {
         String uri = url;
-        if (httpClient.getHostConfiguration().getProtocol() != null) {
-            try {
-                URL u = new URL(url);
-                httpClient.getHostConfiguration().setHost(u.getHost(), u.getPort(), httpClient.getHostConfiguration().getProtocol());
-                uri = u.getFile();
-            } catch (Exception e) {
-                log.warning("[ConsultaTributacao] Erro ao processar URL para modo multithreading: " + e.getMessage());
+        if (certificado.isModoMultithreading()) {
+            if (httpClient.getHostConfiguration().getProtocol() != null) {
+                try {
+                    URL u = new URL(url);
+                    httpClient.getHostConfiguration().setHost(u.getHost(), u.getPort(), httpClient.getHostConfiguration().getProtocol());
+                    uri = u.getFile();
+                } catch (Exception e) {
+                    log.warning("[ConsultaTributacao] Erro ao processar URL para modo multithreading: " + e.getMessage());
+                }
             }
         }
 


### PR DESCRIPTION
### Descrição
Corrige um problema onde requisições da classe `ConsultaTributacao` falhavam com erro `HTTP 403 Forbidden` ou falha de Handshake SSL quando o modo `isModoMultithreading` estava ativado.
### O Problema
Ao utilizar `isModoMultithreading = true`, o `HttpClient` ignora o protocolo customizado (com o certificado específico da thread) se uma URL absoluta for passada diretamente para o `GetMethod`. Isso fazia com que a requisição usasse o contexto SSL padrão da JVM, que não possuía o certificado carregado.
### A Solução
- Modificado o método `executeRequestWithHttpClient` em `ConsultaTributacao.java`.
- Agora, quando um protocolo customizado está presente, o `HostConfiguration` é configurado explicitamente e apenas a URI relativa (path + query) é passada ao método GET.
- Isso força o `HttpClient` a respeitar o protocolo configurado na thread.
### Testes
Testado localmente com certificado A1 e modo multithreading ativado.
- **Antes:** Erro 403 Forbidden.
- **Depois:** Sucesso (HTTP 200) e retorno do JSON correto.