### PR TITLE
fix: adiciona gEstornoCred em TCIBS para suporte ao grupo de estorno …

### DIFF
--- a/src/main/java/br/com/swconsultoria/nfe/schema_4/consReciNFe/TCIBS.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schema_4/consReciNFe/TCIBS.java
@@ -86,7 +86,8 @@ import javax.xml.bind.annotation.XmlType;
     "vibs",
     "gcbs",
     "gTribRegular",
-    "gTribCompraGov"
+    "gTribCompraGov",
+    "gEstornoCred"
 })
 public class TCIBS {
 
@@ -104,6 +105,8 @@ public class TCIBS {
     protected TTribRegular gTribRegular;
     @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
     protected TTribCompraGov gTribCompraGov;
+    @XmlElement(name = "gEstornoCred", namespace = "http://www.portalfiscal.inf.br/nfe")
+    protected TEstornoCred gEstornoCred;
 
     /**
      * Obtém o valor da propriedade vbc.
@@ -271,6 +274,14 @@ public class TCIBS {
      */
     public void setGTribCompraGov(TTribCompraGov value) {
         this.gTribCompraGov = value;
+    }
+
+    public TEstornoCred getGEstornoCred() {
+        return gEstornoCred;
+    }
+
+    public void setGEstornoCred(TEstornoCred value) {
+        this.gEstornoCred = value;
     }
 
 

--- a/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TCIBS.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schema_4/enviNFe/TCIBS.java
@@ -86,7 +86,8 @@ import javax.xml.bind.annotation.XmlType;
     "vibs",
     "gcbs",
     "gTribRegular",
-    "gTribCompraGov"
+    "gTribCompraGov",
+    "gEstornoCred"
 })
 public class TCIBS {
 
@@ -104,6 +105,8 @@ public class TCIBS {
     protected TTribRegular gTribRegular;
     @XmlElement(namespace = "http://www.portalfiscal.inf.br/nfe")
     protected TTribCompraGov gTribCompraGov;
+    @XmlElement(name = "gEstornoCred", namespace = "http://www.portalfiscal.inf.br/nfe")
+    protected TEstornoCred gEstornoCred;
 
     /**
      * Obtém o valor da propriedade vbc.
@@ -271,6 +274,14 @@ public class TCIBS {
      */
     public void setGTribCompraGov(TTribCompraGov value) {
         this.gTribCompraGov = value;
+    }
+
+    public TEstornoCred getGEstornoCred() {
+        return gEstornoCred;
+    }
+
+    public void setGEstornoCred(TEstornoCred value) {
+        this.gEstornoCred = value;
     }
 
 


### PR DESCRIPTION
 Ao transmitir uma NF-e de débito do tipo 07 (Perda em estoque), o SEFAZ rejeita com o erro:

  ▎ 1173 - Grupo de Estorno de Credito nao informado [nItem:1]
  
  A causa é que a classe TCIBS (que mapeia o elemento gIBSCBS) não possui o campo gEstornoCred, que é exigido pela NT 2024/004 (UB116, filho de UB12 gIBSCBS).
  
  O campo gEstornoCred existe na lib, mas está declarado em TTribNFe (nível acima), o que também causa rejeição do SEFAZ ao tentar usá-lo ali.
  
  Alterações:
  - Adicionado gEstornoCred ao propOrder de TCIBS em enviNFe e consReciNFe
  - Adicionado campo protected TEstornoCred gEstornoCred com getter e setter
  - A classe TEstornoCred já existia na lib com vIBSEstCred e vCBSEstCred