### PR TITLE
NT 2025.002-RTC v1.40: campos novos do leiaute da NF-e e correção do evento 211110

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,18 @@
 
     <groupId>br.com.swconsultoria</groupId>
     <artifactId>java-nfe</artifactId>
-    <version>4.1.1</version>
+    <version>4.1.1-evoli1</version>
     <name>Java_NFe</name>
     <description>Api java para consumo do webService de nota fiscal eletronica</description>
     <url>https://github.com/Samuel-Oliveira/Java_NFe</url>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/edivaldoms/Java_NFe</url>
+        </repository>
+    </distributionManagement>
 
     <licenses>
         <license>
@@ -27,6 +35,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+        <!-- Fork Evoli: publicacao no GitHub Packages, sem assinatura GPG do Maven Central -->
+        <gpg.skip>true</gpg.skip>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,18 +4,10 @@
 
     <groupId>br.com.swconsultoria</groupId>
     <artifactId>java-nfe</artifactId>
-    <version>4.1.1-evoli1</version>
+    <version>4.1.2-SNAPSHOT</version>
     <name>Java_NFe</name>
     <description>Api java para consumo do webService de nota fiscal eletronica</description>
     <url>https://github.com/Samuel-Oliveira/Java_NFe</url>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
-            <url>https://maven.pkg.github.com/edivaldoms/Java_NFe</url>
-        </repository>
-    </distributionManagement>
 
     <licenses>
         <license>
@@ -35,8 +27,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-        <!-- Fork Evoli: publicacao no GitHub Packages, sem assinatura GPG do Maven Central -->
-        <gpg.skip>true</gpg.skip>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>1.8</java.version>

--- a/src/main/java/br/com/swconsultoria/nfe/schemas/TCIBS.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schemas/TCIBS.java
@@ -286,14 +286,15 @@ public class TCIBS {
      *         &lt;element name="gDif" type="{http://www.portalfiscal.inf.br/nfe}TDif" minOccurs="0"/>
      *         &lt;element name="gDevTrib" type="{http://www.portalfiscal.inf.br/nfe}TDevTrib" minOccurs="0"/>
      *         &lt;element name="gRed" type="{http://www.portalfiscal.inf.br/nfe}TRed" minOccurs="0"/>
+     *         &lt;element name="gALCZFMCBS" minOccurs="0"/>
      *         &lt;element name="vCBS" type="{http://www.portalfiscal.inf.br/nfe}TDec1302RTC"/>
      *       &lt;/sequence>
      *     &lt;/restriction>
      *   &lt;/complexContent>
      * &lt;/complexType>
      * </pre>
-     * 
-     * 
+     *
+     *
      */
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
@@ -301,6 +302,7 @@ public class TCIBS {
         "gDif",
         "gDevTrib",
         "gRed",
+        "galczfmcbs",
         "vcbs"
     })
     public static class GCBS {
@@ -310,6 +312,8 @@ public class TCIBS {
         protected TDif gDif;
         protected TDevTrib gDevTrib;
         protected TRed gRed;
+        @XmlElement(name = "gALCZFMCBS")
+        protected TCIBS.GCBS.GALCZFMCBS galczfmcbs;
         @XmlElement(name = "vCBS", required = true)
         protected String vcbs;
 
@@ -431,6 +435,169 @@ public class TCIBS {
          */
         public void setVCBS(String value) {
             this.vcbs = value;
+        }
+
+        /**
+         * Obtém o valor da propriedade galczfmcbs.
+         *
+         * @return
+         *     possible object is
+         *     {@link TCIBS.GCBS.GALCZFMCBS }
+         *
+         */
+        public TCIBS.GCBS.GALCZFMCBS getGALCZFMCBS() {
+            return galczfmcbs;
+        }
+
+        /**
+         * Define o valor da propriedade galczfmcbs.
+         *
+         * @param value
+         *     allowed object is
+         *     {@link TCIBS.GCBS.GALCZFMCBS }
+         *
+         */
+        public void setGALCZFMCBS(TCIBS.GCBS.GALCZFMCBS value) {
+            this.galczfmcbs = value;
+        }
+
+
+        /**
+         * Grupo de operações em áreas incentivadas (ALC/ZFM) - CBS (alíquota zero).
+         * Criado pela NT 2025.002 v1.40 (UB66a), arts. 451 e 466 da LC 214/2025.
+         *
+         * <p>Classe Java de anonymous complex type.
+         *
+         * <pre>
+         * &lt;complexType>
+         *   &lt;complexContent>
+         *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+         *       &lt;sequence>
+         *         &lt;element name="tpALCZFMCBS" type="{http://www.portalfiscal.inf.br/nfe}TtpALCZFMCBS"/>
+         *         &lt;element name="nProcSuframa" minOccurs="0"/>
+         *         &lt;element name="pAliqEfetRegCBS" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04RTC"/>
+         *         &lt;element name="vTribRegCBS" type="{http://www.portalfiscal.inf.br/nfe}TDec1302RTC"/>
+         *       &lt;/sequence>
+         *     &lt;/restriction>
+         *   &lt;/complexContent>
+         * &lt;/complexType>
+         * </pre>
+         *
+         *
+         */
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {
+            "tpALCZFMCBS",
+            "nProcSuframa",
+            "pAliqEfetRegCBS",
+            "vTribRegCBS"
+        })
+        public static class GALCZFMCBS {
+
+            @XmlElement(required = true)
+            protected String tpALCZFMCBS;
+            protected String nProcSuframa;
+            @XmlElement(required = true)
+            protected String pAliqEfetRegCBS;
+            @XmlElement(required = true)
+            protected String vTribRegCBS;
+
+            /**
+             * Obtém o valor da propriedade tpALCZFMCBS.
+             *
+             * @return
+             *     possible object is
+             *     {@link String }
+             *
+             */
+            public String getTpALCZFMCBS() {
+                return tpALCZFMCBS;
+            }
+
+            /**
+             * Define o valor da propriedade tpALCZFMCBS.
+             *
+             * @param value
+             *     allowed object is
+             *     {@link String }
+             *
+             */
+            public void setTpALCZFMCBS(String value) {
+                this.tpALCZFMCBS = value;
+            }
+
+            /**
+             * Obtém o valor da propriedade nProcSuframa.
+             *
+             * @return
+             *     possible object is
+             *     {@link String }
+             *
+             */
+            public String getNProcSuframa() {
+                return nProcSuframa;
+            }
+
+            /**
+             * Define o valor da propriedade nProcSuframa.
+             *
+             * @param value
+             *     allowed object is
+             *     {@link String }
+             *
+             */
+            public void setNProcSuframa(String value) {
+                this.nProcSuframa = value;
+            }
+
+            /**
+             * Obtém o valor da propriedade pAliqEfetRegCBS.
+             *
+             * @return
+             *     possible object is
+             *     {@link String }
+             *
+             */
+            public String getPAliqEfetRegCBS() {
+                return pAliqEfetRegCBS;
+            }
+
+            /**
+             * Define o valor da propriedade pAliqEfetRegCBS.
+             *
+             * @param value
+             *     allowed object is
+             *     {@link String }
+             *
+             */
+            public void setPAliqEfetRegCBS(String value) {
+                this.pAliqEfetRegCBS = value;
+            }
+
+            /**
+             * Obtém o valor da propriedade vTribRegCBS.
+             *
+             * @return
+             *     possible object is
+             *     {@link String }
+             *
+             */
+            public String getVTribRegCBS() {
+                return vTribRegCBS;
+            }
+
+            /**
+             * Define o valor da propriedade vTribRegCBS.
+             *
+             * @param value
+             *     allowed object is
+             *     {@link String }
+             *
+             */
+            public void setVTribRegCBS(String value) {
+                this.vTribRegCBS = value;
+            }
+
         }
 
     }

--- a/src/main/java/br/com/swconsultoria/nfe/schemas/TCompraGov.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schemas/TCompraGov.java
@@ -1,6 +1,8 @@
 
 package br.com.swconsultoria.nfe.schemas;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -22,19 +24,21 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="tpEnteGov" type="{http://www.portalfiscal.inf.br/nfe}TEnteGov"/>
  *         &lt;element name="pRedutor" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04RTC"/>
  *         &lt;element name="tpOperGov" type="{http://www.portalfiscal.inf.br/nfe}TOperCompraGov"/>
+ *         &lt;element name="refDFeAnt" type="{http://www.portalfiscal.inf.br/nfe}TChNFe" maxOccurs="99" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
+ *
+ *
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "TCompraGov", propOrder = {
     "tpEnteGov",
     "pRedutor",
-    "tpOperGov"
+    "tpOperGov",
+    "refDFeAnt"
 })
 public class TCompraGov {
 
@@ -44,6 +48,7 @@ public class TCompraGov {
     protected String pRedutor;
     @XmlElement(required = true)
     protected String tpOperGov;
+    protected List<String> refDFeAnt;
 
     /**
      * Obtém o valor da propriedade tpEnteGov.
@@ -115,6 +120,27 @@ public class TCompraGov {
      */
     public void setTpOperGov(String value) {
         this.tpOperGov = value;
+    }
+
+    /**
+     * Gets the value of the refDFeAnt property.
+     *
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     *
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link String }
+     *
+     *
+     */
+    public List<String> getRefDFeAnt() {
+        if (refDFeAnt == null) {
+            refDFeAnt = new ArrayList<String>();
+        }
+        return this.refDFeAnt;
     }
 
 }

--- a/src/main/java/br/com/swconsultoria/nfe/schemas/TDevTrib.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schemas/TDevTrib.java
@@ -19,23 +19,50 @@ import javax.xml.bind.annotation.XmlType;
  *   &lt;complexContent>
  *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
  *       &lt;sequence>
+ *         &lt;element name="pDevTrib" type="{http://www.portalfiscal.inf.br/nfe}TDec0302a04RTC" minOccurs="0"/>
  *         &lt;element name="vDevTrib" type="{http://www.portalfiscal.inf.br/nfe}TDec1302RTC"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
+ *
+ *
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "TDevTrib", propOrder = {
+    "pDevTrib",
     "vDevTrib"
 })
 public class TDevTrib {
 
+    protected String pDevTrib;
     @XmlElement(required = true)
     protected String vDevTrib;
+
+    /**
+     * Obtém o valor da propriedade pDevTrib.
+     *
+     * @return
+     *     possible object is
+     *     {@link String }
+     *
+     */
+    public String getPDevTrib() {
+        return pDevTrib;
+    }
+
+    /**
+     * Define o valor da propriedade pDevTrib.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *
+     */
+    public void setPDevTrib(String value) {
+        this.pDevTrib = value;
+    }
 
     /**
      * Obtém o valor da propriedade vDevTrib.

--- a/src/main/java/br/com/swconsultoria/nfe/schemas/TNFe.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schemas/TNFe.java
@@ -34502,7 +34502,8 @@ public class TNFe {
             "iest",
             "im",
             "cnae",
-            "crt"
+            "crt",
+            "isufEmit"
         })
         public static class Emit {
 
@@ -34525,6 +34526,8 @@ public class TNFe {
             protected String cnae;
             @XmlElement(name = "CRT", required = true)
             protected String crt;
+            @XmlElement(name = "ISUFEmit")
+            protected String isufEmit;
 
             /**
              * Obtém o valor da propriedade cnpj.
@@ -34764,6 +34767,31 @@ public class TNFe {
              */
             public void setCRT(String value) {
                 this.crt = value;
+            }
+
+            /**
+             * Obtém o valor da propriedade isufEmit.
+             * Inscrição do emitente na Suframa (C22, NT 2025.002 v1.40).
+             *
+             * @return
+             *     possible object is
+             *     {@link String }
+             *
+             */
+            public String getISUFEmit() {
+                return isufEmit;
+            }
+
+            /**
+             * Define o valor da propriedade isufEmit.
+             *
+             * @param value
+             *     allowed object is
+             *     {@link String }
+             *
+             */
+            public void setISUFEmit(String value) {
+                this.isufEmit = value;
             }
 
         }
@@ -35200,6 +35228,7 @@ public class TNFe {
             "indFinal",
             "indPres",
             "indIntermed",
+            "cIndOp",
             "procEmi",
             "verProc",
             "dhCont",
@@ -35250,6 +35279,7 @@ public class TNFe {
             @XmlElement(required = true)
             protected String indPres;
             protected String indIntermed;
+            protected String cIndOp;
             @XmlElement(required = true)
             protected String procEmi;
             @XmlElement(required = true)
@@ -35811,6 +35841,31 @@ public class TNFe {
              */
             public void setIndIntermed(String value) {
                 this.indIntermed = value;
+            }
+
+            /**
+             * Obtém o valor da propriedade cIndOp.
+             * Código indicador do local da operação de fornecimento (B25d, NT 2025.002 v1.40).
+             *
+             * @return
+             *     possible object is
+             *     {@link String }
+             *
+             */
+            public String getCIndOp() {
+                return cIndOp;
+            }
+
+            /**
+             * Define o valor da propriedade cIndOp.
+             *
+             * @param value
+             *     allowed object is
+             *     {@link String }
+             *
+             */
+            public void setCIndOp(String value) {
+                this.cIndOp = value;
             }
 
             /**

--- a/src/main/java/br/com/swconsultoria/nfe/schemas_eventos/DetEvento211110.java
+++ b/src/main/java/br/com/swconsultoria/nfe/schemas_eventos/DetEvento211110.java
@@ -6,98 +6,41 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * <p>Classe Java de anonymous complex type.
- * 
- * <p>O seguinte fragmento do esquema especifica o conteúdo esperado contido dentro desta classe.
- * 
+ * Evento 211110 - Solicitação de Apropriação de crédito presumido (NT 2025.002-RTC).
+ *
+ * <p>Estrutura conforme o e211110_v1.00.xsd do pacote "Schema dos eventos da NT 2025.002 v.1.40 -
+ * RTC", publicado em 27/07/2026:
+ *
  * <pre>
  * &lt;complexType>
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *   &lt;sequence>
+ *     &lt;element name="descEvento"> (enumeration "Solicitação de Apropriação de crédito presumido")
+ *     &lt;element name="cOrgaoAutor" type="TCodUfIBGE"/>
+ *     &lt;element name="tpAutor"> (enumeration "1", "2")
+ *     &lt;element name="verAplic" type="TVerAplic"/>
+ *     &lt;element name="gCredPresOper" maxOccurs="990">
  *       &lt;sequence>
- *         &lt;element name="descEvento">
- *           &lt;simpleType>
- *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *               &lt;enumeration value="Solicitação de Apropriação de crédito presumido"/>
- *             &lt;/restriction>
- *           &lt;/simpleType>
+ *         &lt;element name="vBCCredPres" type="TDec_1302"/>
+ *         &lt;element name="cCredPres"/>
+ *         &lt;element name="gIBSCredPres" minOccurs="0">
+ *           &lt;sequence>
+ *             &lt;element name="pCredPres" type="TDec_0302_04"/>
+ *             &lt;element name="vCredPres" type="TDec1302"/>
+ *           &lt;/sequence>
  *         &lt;/element>
- *         &lt;element name="cOrgaoAutor" type="{http://www.portalfiscal.inf.br/nfe}TCodUfIBGE"/>
- *         &lt;element name="tpAutor">
- *           &lt;simpleType>
- *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *               &lt;enumeration value="2"/>
- *             &lt;/restriction>
- *           &lt;/simpleType>
- *         &lt;/element>
- *         &lt;element name="verAplic" type="{http://www.portalfiscal.inf.br/nfe}TVerAplic"/>
- *         &lt;element name="gCredPres" maxOccurs="990">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="vBC" type="{http://www.portalfiscal.inf.br/nfe}TDec_1302"/>
- *                   &lt;element name="gIBS" minOccurs="0">
- *                     &lt;complexType>
- *                       &lt;complexContent>
- *                         &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                           &lt;sequence>
- *                             &lt;element name="cCredPres">
- *                               &lt;simpleType>
- *                                 &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *                                   &lt;whiteSpace value="preserve"/>
- *                                   &lt;pattern value="[0-9]{2}"/>
- *                                 &lt;/restriction>
- *                               &lt;/simpleType>
- *                             &lt;/element>
- *                             &lt;element name="pCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04"/>
- *                             &lt;element name="vCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec1302"/>
- *                           &lt;/sequence>
- *                         &lt;/restriction>
- *                       &lt;/complexContent>
- *                     &lt;/complexType>
- *                   &lt;/element>
- *                   &lt;element name="gCBS" minOccurs="0">
- *                     &lt;complexType>
- *                       &lt;complexContent>
- *                         &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                           &lt;sequence>
- *                             &lt;element name="cCredPres">
- *                               &lt;simpleType>
- *                                 &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *                                   &lt;whiteSpace value="preserve"/>
- *                                   &lt;pattern value="[0-9]{2}"/>
- *                                 &lt;/restriction>
- *                               &lt;/simpleType>
- *                             &lt;/element>
- *                             &lt;element name="pCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04"/>
- *                             &lt;element name="vCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec1302"/>
- *                           &lt;/sequence>
- *                         &lt;/restriction>
- *                       &lt;/complexContent>
- *                     &lt;/complexType>
- *                   &lt;/element>
- *                 &lt;/sequence>
- *                 &lt;attribute name="nItem" use="required" type="{http://www.portalfiscal.inf.br/nfe}TnItem" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
+ *         &lt;element name="gCBSCredPres" minOccurs="0">
+ *           &lt;sequence>
+ *             &lt;element name="pCredPres" type="TDec_0302_04"/>
+ *             &lt;element name="vCredPres" type="TDec1302"/>
+ *           &lt;/sequence>
  *         &lt;/element>
  *       &lt;/sequence>
- *       &lt;attribute name="versao">
- *         &lt;simpleType>
- *           &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *             &lt;whiteSpace value="preserve"/>
- *             &lt;enumeration value="1.00"/>
- *           &lt;/restriction>
- *         &lt;/simpleType>
- *       &lt;/attribute>
- *     &lt;/restriction>
- *   &lt;/complexContent>
+ *       &lt;attribute name="nItem" type="TnItem" use="required"/>
+ *     &lt;/element>
+ *   &lt;/sequence>
+ *   &lt;attribute name="versao"> (enumeration "1.00")
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {
@@ -105,7 +48,7 @@ import java.util.List;
     "cOrgaoAutor",
     "tpAutor",
     "verAplic",
-    "gCredPres"
+    "gCredPresOper"
 })
 @XmlRootElement(name = "detEvento")
 public class DetEvento211110 {
@@ -119,17 +62,17 @@ public class DetEvento211110 {
     @XmlElement(required = true)
     protected String verAplic;
     @XmlElement(required = true)
-    protected List<DetEvento211110.GCredPres> gCredPres;
+    protected List<DetEvento211110.GCredPresOper> gCredPresOper;
     @XmlAttribute(name = "versao")
     protected String versao;
 
     /**
      * Obtém o valor da propriedade descEvento.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link String }
-     *     
+     *
      */
     public String getDescEvento() {
         return descEvento;
@@ -137,11 +80,11 @@ public class DetEvento211110 {
 
     /**
      * Define o valor da propriedade descEvento.
-     * 
+     *
      * @param value
      *     allowed object is
      *     {@link String }
-     *     
+     *
      */
     public void setDescEvento(String value) {
         this.descEvento = value;
@@ -149,11 +92,11 @@ public class DetEvento211110 {
 
     /**
      * Obtém o valor da propriedade cOrgaoAutor.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link String }
-     *     
+     *
      */
     public String getCOrgaoAutor() {
         return cOrgaoAutor;
@@ -161,11 +104,11 @@ public class DetEvento211110 {
 
     /**
      * Define o valor da propriedade cOrgaoAutor.
-     * 
+     *
      * @param value
      *     allowed object is
      *     {@link String }
-     *     
+     *
      */
     public void setCOrgaoAutor(String value) {
         this.cOrgaoAutor = value;
@@ -173,11 +116,11 @@ public class DetEvento211110 {
 
     /**
      * Obtém o valor da propriedade tpAutor.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link String }
-     *     
+     *
      */
     public String getTpAutor() {
         return tpAutor;
@@ -185,11 +128,11 @@ public class DetEvento211110 {
 
     /**
      * Define o valor da propriedade tpAutor.
-     * 
+     *
      * @param value
      *     allowed object is
      *     {@link String }
-     *     
+     *
      */
     public void setTpAutor(String value) {
         this.tpAutor = value;
@@ -197,11 +140,11 @@ public class DetEvento211110 {
 
     /**
      * Obtém o valor da propriedade verAplic.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link String }
-     *     
+     *
      */
     public String getVerAplic() {
         return verAplic;
@@ -209,52 +152,44 @@ public class DetEvento211110 {
 
     /**
      * Define o valor da propriedade verAplic.
-     * 
+     *
      * @param value
      *     allowed object is
      *     {@link String }
-     *     
+     *
      */
     public void setVerAplic(String value) {
         this.verAplic = value;
     }
 
     /**
-     * Gets the value of the gCredPres property.
-     * 
+     * Gets the value of the gCredPresOper property.
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
-     * This is why there is not a <CODE>set</CODE> method for the gCredPres property.
-     * 
-     * <p>
-     * For example, to add a new item, do as follows:
-     * <pre>
-     *    getGCredPres().add(newItem);
-     * </pre>
-     * 
-     * 
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
-     * {@link DetEvento211110.GCredPres }
-     * 
-     * 
+     * {@link DetEvento211110.GCredPresOper }
+     *
+     *
      */
-    public List<DetEvento211110.GCredPres> getGCredPres() {
-        if (gCredPres == null) {
-            gCredPres = new ArrayList<DetEvento211110.GCredPres>();
+    public List<DetEvento211110.GCredPresOper> getGCredPresOper() {
+        if (gCredPresOper == null) {
+            gCredPresOper = new ArrayList<DetEvento211110.GCredPresOper>();
         }
-        return this.gCredPres;
+        return this.gCredPresOper;
     }
 
     /**
      * Obtém o valor da propriedade versao.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link String }
-     *     
+     *
      */
     public String getVersao() {
         return versao;
@@ -262,11 +197,11 @@ public class DetEvento211110 {
 
     /**
      * Define o valor da propriedade versao.
-     * 
+     *
      * @param value
      *     allowed object is
      *     {@link String }
-     *     
+     *
      */
     public void setVersao(String value) {
         this.versao = value;
@@ -274,161 +209,132 @@ public class DetEvento211110 {
 
 
     /**
-     * <p>Classe Java de anonymous complex type.
-     * 
-     * <p>O seguinte fragmento do esquema especifica o conteúdo esperado contido dentro desta classe.
-     * 
-     * <pre>
-     * &lt;complexType>
-     *   &lt;complexContent>
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *       &lt;sequence>
-     *         &lt;element name="vBC" type="{http://www.portalfiscal.inf.br/nfe}TDec_1302"/>
-     *         &lt;element name="gIBS" minOccurs="0">
-     *           &lt;complexType>
-     *             &lt;complexContent>
-     *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *                 &lt;sequence>
-     *                   &lt;element name="cCredPres">
-     *                     &lt;simpleType>
-     *                       &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
-     *                         &lt;whiteSpace value="preserve"/>
-     *                         &lt;pattern value="[0-9]{2}"/>
-     *                       &lt;/restriction>
-     *                     &lt;/simpleType>
-     *                   &lt;/element>
-     *                   &lt;element name="pCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04"/>
-     *                   &lt;element name="vCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec1302"/>
-     *                 &lt;/sequence>
-     *               &lt;/restriction>
-     *             &lt;/complexContent>
-     *           &lt;/complexType>
-     *         &lt;/element>
-     *         &lt;element name="gCBS" minOccurs="0">
-     *           &lt;complexType>
-     *             &lt;complexContent>
-     *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *                 &lt;sequence>
-     *                   &lt;element name="cCredPres">
-     *                     &lt;simpleType>
-     *                       &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
-     *                         &lt;whiteSpace value="preserve"/>
-     *                         &lt;pattern value="[0-9]{2}"/>
-     *                       &lt;/restriction>
-     *                     &lt;/simpleType>
-     *                   &lt;/element>
-     *                   &lt;element name="pCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04"/>
-     *                   &lt;element name="vCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec1302"/>
-     *                 &lt;/sequence>
-     *               &lt;/restriction>
-     *             &lt;/complexContent>
-     *           &lt;/complexType>
-     *         &lt;/element>
-     *       &lt;/sequence>
-     *       &lt;attribute name="nItem" use="required" type="{http://www.portalfiscal.inf.br/nfe}TnItem" />
-     *     &lt;/restriction>
-     *   &lt;/complexContent>
-     * &lt;/complexType>
-     * </pre>
-     * 
-     * 
+     * Grupo de crédito presumido, por item da NF-e.
+     *
+     * <p>A base de cálculo e o código do crédito presumido são do grupo; o percentual e o valor
+     * vêm separados por tributo, em gIBSCredPres e gCBSCredPres.
      */
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
-        "vbc",
-        "gibs",
-        "gcbs"
+        "vBCCredPres",
+        "cCredPres",
+        "gIBSCredPres",
+        "gCBSCredPres"
     })
-    public static class GCredPres {
+    public static class GCredPresOper {
 
-        @XmlElement(name = "vBC", required = true)
-        protected String vbc;
-        @XmlElement(name = "gIBS")
-        protected DetEvento211110.GCredPres.GIBS gibs;
-        @XmlElement(name = "gCBS")
-        protected DetEvento211110.GCredPres.GCBS gcbs;
+        @XmlElement(required = true)
+        protected String vBCCredPres;
+        @XmlElement(required = true)
+        protected String cCredPres;
+        protected DetEvento211110.GCredPresOper.GIBSCredPres gIBSCredPres;
+        protected DetEvento211110.GCredPresOper.GCBSCredPres gCBSCredPres;
         @XmlAttribute(name = "nItem", required = true)
         protected String nItem;
 
         /**
-         * Obtém o valor da propriedade vbc.
-         * 
+         * Obtém o valor da propriedade vBCCredPres.
+         *
          * @return
          *     possible object is
          *     {@link String }
-         *     
+         *
          */
-        public String getVBC() {
-            return vbc;
+        public String getVBCCredPres() {
+            return vBCCredPres;
         }
 
         /**
-         * Define o valor da propriedade vbc.
-         * 
+         * Define o valor da propriedade vBCCredPres.
+         *
          * @param value
          *     allowed object is
          *     {@link String }
-         *     
+         *
          */
-        public void setVBC(String value) {
-            this.vbc = value;
+        public void setVBCCredPres(String value) {
+            this.vBCCredPres = value;
         }
 
         /**
-         * Obtém o valor da propriedade gibs.
-         * 
+         * Obtém o valor da propriedade cCredPres.
+         *
          * @return
          *     possible object is
-         *     {@link DetEvento211110.GCredPres.GIBS }
-         *     
+         *     {@link String }
+         *
          */
-        public DetEvento211110.GCredPres.GIBS getGIBS() {
-            return gibs;
+        public String getCCredPres() {
+            return cCredPres;
         }
 
         /**
-         * Define o valor da propriedade gibs.
-         * 
+         * Define o valor da propriedade cCredPres.
+         *
          * @param value
          *     allowed object is
-         *     {@link DetEvento211110.GCredPres.GIBS }
-         *     
+         *     {@link String }
+         *
          */
-        public void setGIBS(DetEvento211110.GCredPres.GIBS value) {
-            this.gibs = value;
+        public void setCCredPres(String value) {
+            this.cCredPres = value;
         }
 
         /**
-         * Obtém o valor da propriedade gcbs.
-         * 
+         * Obtém o valor da propriedade gIBSCredPres.
+         *
          * @return
          *     possible object is
-         *     {@link DetEvento211110.GCredPres.GCBS }
-         *     
+         *     {@link DetEvento211110.GCredPresOper.GIBSCredPres }
+         *
          */
-        public DetEvento211110.GCredPres.GCBS getGCBS() {
-            return gcbs;
+        public DetEvento211110.GCredPresOper.GIBSCredPres getGIBSCredPres() {
+            return gIBSCredPres;
         }
 
         /**
-         * Define o valor da propriedade gcbs.
-         * 
+         * Define o valor da propriedade gIBSCredPres.
+         *
          * @param value
          *     allowed object is
-         *     {@link DetEvento211110.GCredPres.GCBS }
-         *     
+         *     {@link DetEvento211110.GCredPresOper.GIBSCredPres }
+         *
          */
-        public void setGCBS(DetEvento211110.GCredPres.GCBS value) {
-            this.gcbs = value;
+        public void setGIBSCredPres(DetEvento211110.GCredPresOper.GIBSCredPres value) {
+            this.gIBSCredPres = value;
+        }
+
+        /**
+         * Obtém o valor da propriedade gCBSCredPres.
+         *
+         * @return
+         *     possible object is
+         *     {@link DetEvento211110.GCredPresOper.GCBSCredPres }
+         *
+         */
+        public DetEvento211110.GCredPresOper.GCBSCredPres getGCBSCredPres() {
+            return gCBSCredPres;
+        }
+
+        /**
+         * Define o valor da propriedade gCBSCredPres.
+         *
+         * @param value
+         *     allowed object is
+         *     {@link DetEvento211110.GCredPresOper.GCBSCredPres }
+         *
+         */
+        public void setGCBSCredPres(DetEvento211110.GCredPresOper.GCBSCredPres value) {
+            this.gCBSCredPres = value;
         }
 
         /**
          * Obtém o valor da propriedade nItem.
-         * 
+         *
          * @return
          *     possible object is
          *     {@link String }
-         *     
+         *
          */
         public String getNItem() {
             return nItem;
@@ -436,11 +342,11 @@ public class DetEvento211110 {
 
         /**
          * Define o valor da propriedade nItem.
-         * 
+         *
          * @param value
          *     allowed object is
          *     {@link String }
-         *     
+         *
          */
         public void setNItem(String value) {
             this.nItem = value;
@@ -448,79 +354,27 @@ public class DetEvento211110 {
 
 
         /**
-         * <p>Classe Java de anonymous complex type.
-         * 
-         * <p>O seguinte fragmento do esquema especifica o conteúdo esperado contido dentro desta classe.
-         * 
-         * <pre>
-         * &lt;complexType>
-         *   &lt;complexContent>
-         *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-         *       &lt;sequence>
-         *         &lt;element name="cCredPres">
-         *           &lt;simpleType>
-         *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
-         *               &lt;whiteSpace value="preserve"/>
-         *               &lt;pattern value="[0-9]{2}"/>
-         *             &lt;/restriction>
-         *           &lt;/simpleType>
-         *         &lt;/element>
-         *         &lt;element name="pCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04"/>
-         *         &lt;element name="vCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec1302"/>
-         *       &lt;/sequence>
-         *     &lt;/restriction>
-         *   &lt;/complexContent>
-         * &lt;/complexType>
-         * </pre>
-         * 
-         * 
+         * Crédito presumido do IBS.
          */
         @XmlAccessorType(XmlAccessType.FIELD)
         @XmlType(name = "", propOrder = {
-            "cCredPres",
             "pCredPres",
             "vCredPres"
         })
-        public static class GCBS {
+        public static class GIBSCredPres {
 
-            @XmlElement(required = true)
-            protected String cCredPres;
             @XmlElement(required = true)
             protected String pCredPres;
             @XmlElement(required = true)
             protected String vCredPres;
 
             /**
-             * Obtém o valor da propriedade cCredPres.
-             * 
-             * @return
-             *     possible object is
-             *     {@link String }
-             *     
-             */
-            public String getCCredPres() {
-                return cCredPres;
-            }
-
-            /**
-             * Define o valor da propriedade cCredPres.
-             * 
-             * @param value
-             *     allowed object is
-             *     {@link String }
-             *     
-             */
-            public void setCCredPres(String value) {
-                this.cCredPres = value;
-            }
-
-            /**
              * Obtém o valor da propriedade pCredPres.
-             * 
+             *
              * @return
              *     possible object is
              *     {@link String }
-             *     
+             *
              */
             public String getPCredPres() {
                 return pCredPres;
@@ -528,11 +382,11 @@ public class DetEvento211110 {
 
             /**
              * Define o valor da propriedade pCredPres.
-             * 
+             *
              * @param value
              *     allowed object is
              *     {@link String }
-             *     
+             *
              */
             public void setPCredPres(String value) {
                 this.pCredPres = value;
@@ -540,11 +394,11 @@ public class DetEvento211110 {
 
             /**
              * Obtém o valor da propriedade vCredPres.
-             * 
+             *
              * @return
              *     possible object is
              *     {@link String }
-             *     
+             *
              */
             public String getVCredPres() {
                 return vCredPres;
@@ -552,11 +406,11 @@ public class DetEvento211110 {
 
             /**
              * Define o valor da propriedade vCredPres.
-             * 
+             *
              * @param value
              *     allowed object is
              *     {@link String }
-             *     
+             *
              */
             public void setVCredPres(String value) {
                 this.vCredPres = value;
@@ -566,79 +420,27 @@ public class DetEvento211110 {
 
 
         /**
-         * <p>Classe Java de anonymous complex type.
-         * 
-         * <p>O seguinte fragmento do esquema especifica o conteúdo esperado contido dentro desta classe.
-         * 
-         * <pre>
-         * &lt;complexType>
-         *   &lt;complexContent>
-         *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-         *       &lt;sequence>
-         *         &lt;element name="cCredPres">
-         *           &lt;simpleType>
-         *             &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
-         *               &lt;whiteSpace value="preserve"/>
-         *               &lt;pattern value="[0-9]{2}"/>
-         *             &lt;/restriction>
-         *           &lt;/simpleType>
-         *         &lt;/element>
-         *         &lt;element name="pCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec_0302_04"/>
-         *         &lt;element name="vCredPres" type="{http://www.portalfiscal.inf.br/nfe}TDec1302"/>
-         *       &lt;/sequence>
-         *     &lt;/restriction>
-         *   &lt;/complexContent>
-         * &lt;/complexType>
-         * </pre>
-         * 
-         * 
+         * Crédito presumido da CBS.
          */
         @XmlAccessorType(XmlAccessType.FIELD)
         @XmlType(name = "", propOrder = {
-            "cCredPres",
             "pCredPres",
             "vCredPres"
         })
-        public static class GIBS {
+        public static class GCBSCredPres {
 
-            @XmlElement(required = true)
-            protected String cCredPres;
             @XmlElement(required = true)
             protected String pCredPres;
             @XmlElement(required = true)
             protected String vCredPres;
 
             /**
-             * Obtém o valor da propriedade cCredPres.
-             * 
-             * @return
-             *     possible object is
-             *     {@link String }
-             *     
-             */
-            public String getCCredPres() {
-                return cCredPres;
-            }
-
-            /**
-             * Define o valor da propriedade cCredPres.
-             * 
-             * @param value
-             *     allowed object is
-             *     {@link String }
-             *     
-             */
-            public void setCCredPres(String value) {
-                this.cCredPres = value;
-            }
-
-            /**
              * Obtém o valor da propriedade pCredPres.
-             * 
+             *
              * @return
              *     possible object is
              *     {@link String }
-             *     
+             *
              */
             public String getPCredPres() {
                 return pCredPres;
@@ -646,11 +448,11 @@ public class DetEvento211110 {
 
             /**
              * Define o valor da propriedade pCredPres.
-             * 
+             *
              * @param value
              *     allowed object is
              *     {@link String }
-             *     
+             *
              */
             public void setPCredPres(String value) {
                 this.pCredPres = value;
@@ -658,11 +460,11 @@ public class DetEvento211110 {
 
             /**
              * Obtém o valor da propriedade vCredPres.
-             * 
+             *
              * @return
              *     possible object is
              *     {@link String }
-             *     
+             *
              */
             public String getVCredPres() {
                 return vCredPres;
@@ -670,11 +472,11 @@ public class DetEvento211110 {
 
             /**
              * Define o valor da propriedade vCredPres.
-             * 
+             *
              * @param value
              *     allowed object is
              *     {@link String }
-             *     
+             *
              */
             public void setVCredPres(String value) {
                 this.vCredPres = value;


### PR DESCRIPTION
Adequa a lib à **NT 2025.002-RTC v1.40** (leiaute publicado em 10/07/2026, schemas dos eventos em 27/07/2026), cujo prazo de produção é **03/08/2026** — data em que o preenchimento dos grupos IBS/CBS deixa de ser facultativo e passa a ser exigido por regra de validação. A 4.1.1 está no nível v1.30 e não tem nenhum dos campos abaixo.

São dois assuntos independentes, um commit cada.

## 1. Campos novos do leiaute

Cinco campos que a v1.40 acrescentou, todos em classes que já existiam:

| Classe | Campo | Referência no MOC | Posição |
|---|---|---|---|
| `TNFe.InfNFe.Ide` | `cIndOp` | B25d | depois de `indIntermed` |
| `TNFe.InfNFe.Emit` | `ISUFEmit` | C22 | depois de `CRT` |
| `TCompraGov` | `refDFeAnt` (0–99) | BB05 | depois de `tpOperGov` |
| `TDevTrib` | `pDevTrib` | UB24a / UB43a / UB62a | antes de `vDevTrib` |
| `TCIBS.GCBS` | `gALCZFMCBS` (grupo novo) | UB66a | entre `gRed` e `vCBS` |

`gALCZFMCBS` entrou como classe aninhada de `TCIBS.GCBS`, com `tpALCZFMCBS`, `nProcSuframa`, `pAliqEfetRegCBS` e `vTribRegCBS`. Vale notar que o `leiauteNFe_v4.00.xsd` tem **dois** tipos parecidos: `TALCZFMCBS`, de dois elementos, e `TALCZFMCBS_NFe`, de quatro. A NF-e chega nele por `TTribNFe` -> `TCIBS_NFe` -> `TALCZFMCBS_NFe`, então é o de quatro.

Em todos os casos o `propOrder` do `@XmlType` foi atualizado junto — o XSD é `xs:sequence`, e ordem errada é rejeição 215.

`ObjectFactory` e `XsdEnum` não foram tocados: nenhum dos campos é elemento de topo.

## 2. `DetEvento211110` conforme o XSD oficial

A classe do evento 211110 (Solicitação de Apropriação de crédito presumido) seguia uma minuta anterior à publicação de 27/07/2026. Confrontada com o `e211110_v1.00.xsd`, divergia em cinco pontos, cada um deles suficiente para a SEFAZ rejeitar o evento:

| 4.1.1 | XSD oficial |
|---|---|
| `gCredPres` | `gCredPresOper` |
| `vBC` | `vBCCredPres` |
| `cCredPres` repetido dentro de `gIBS` e de `gCBS` | `cCredPres` único, no nível do grupo |
| `gIBS` / `gCBS` | `gIBSCredPres` / `gCBSCredPres` |
| `tpAutor` aceitando só `"2"` | `"1"` ou `"2"` |

É uma quebra de API para quem já usava a classe, mas o código anterior não tinha como produzir um XML aceito pela SEFAZ.

## Verificação

- `mvn test`: **2157 testes, 0 falhas**.
- XML gerado pelas classes validado contra o `leiauteNFe_v4.00.xsd` do PL_010e v1.02 e contra os XSDs do pacote "Schema dos eventos da NT 2025.002 v.1.40 - RTC" — inclusive a ordem dos elementos dos grupos IBS/CBS.
- `e112110` e `e211110` validam.

## Observações

- O bump para `4.1.2-SNAPSHOT` no `pom.xml` está aí só para eu conseguir consumir o fork enquanto isso não é liberado; fique à vontade para descartar essa linha.
- **v1.50** (monofásica de combustíveis reformulada, `gpBioDiferenca`, `adRemIS`) ficou de fora: produção só em 03/11/2026 e o schema ainda não saiu.
- O `schemas.zip` não foi atualizado — pelo que vi só os testes da própria lib o usam. Se preferir, atualizo aqui.
- Os demais eventos da reforma continuam como estão; só revisei o 211110 porque é um dos dois que estou usando.
